### PR TITLE
Feat: Oauth2 and OpenID Connect core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,29 @@ run-tests.log
 /test/*/*/*/*.log
 /test/*/*/*/*.out
 
+
+# Added by horde-components QC --fix-qc-issues
+# Build artifacts directory
+/build/
+# Composer dependencies directory
+/vendor/
+# Composer lock file (libraries should not commit lock files)
+/composer.lock
+# PHPStorm IDE settings
+/.idea/
+# VSCode IDE settings
+/.vscode/
+# Claude Code CLI cache and state
+/.claude/
+# Cline extension data
+/.cline/
+# PHP CS Fixer cache file
+/.php-cs-fixer.cache
+# PHPUnit result cache
+/.phpunit.result.cache
+# PHPUnit Cache (other)
+/.phpunit.cache
+# PHPStan local configuration
+/phpstan.neon
+# PHPStan cache directory
+/.phpstan.cache/

--- a/.horde.yml
+++ b/.horde.yml
@@ -1,11 +1,12 @@
 ---
 id: Oauth
 name: Oauth
-full: OAuth client library
+full: OAuth 1.0a, OAuth 2.0 and OpenID Connect library
 description: >-
-  A library that provides an OAuth consumer (http://oauth.net) and OAuth
-  infrastructure, and in the future will provide an OAuth server.
-list: dev
+  A library that provides OAuth 1.0a consumer support, OAuth 2.0
+  authorization server and client, and OpenID Connect provider
+  capabilities for the Horde framework.
+list: horde
 type: library
 homepage: https://www.horde.org/libraries/Horde_Oauth
 authors:
@@ -15,22 +16,42 @@ authors:
     email: chuck@horde.org
     active: false
     role: lead
+  -
+    name: Ralf Lang
+    user: ralf.lang
+    email: ralf.lang@ralf-lang.de
+    role: lead
+    active: true
 version:
-  release: 3.0.0alpha2
-  api: 1.0.0
+  release: 4.0.0alpha1
+  api: 4.0.0
 state:
   release: alpha
-  api: stable
+  api: alpha
 license:
   identifier: BSD-2-Clause
   uri: http://www.horde.org/licenses/bsd
 dependencies:
   required:
-    php: ^7
+    php: ^8.1
     composer:
-      horde/exception: ^3
-      horde/http: ^3
-      horde/util: ^3
+      horde/jwt: ^1
+      psr/http-message: ^2
+      psr/http-factory: ^1.0.2
+      psr/http-client: ^1.0.3
+      psr/http-server-handler: ^1.0.2
+      psr/http-server-middleware: ^1.0.2
     ext:
-      hash: '*'
-      openssl: '*'
+      - hash
+      - json
+      - openssl
+keywords:
+  - rfc6749
+  - rfc7636
+  - oauth2
+  - oidc
+  - openid-connect
+vendor: horde
+quality:
+  phpstan:
+    level: 3

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "minimum-stability": "dev",
     "name": "horde/oauth",
-    "description": "OAuth client library",
+    "description": "OAuth 1.0a, OAuth 2.0 and OpenID Connect library",
     "type": "library",
     "homepage": "https://www.horde.org/libraries/Horde_Oauth",
     "license": "BSD-2-Clause",
@@ -10,28 +10,55 @@
             "name": "Chuck Hagenbuch",
             "email": "chuck@horde.org",
             "role": "lead"
+        },
+        {
+            "name": "Ralf Lang",
+            "email": "ralf.lang@ralf-lang.de",
+            "role": "lead"
         }
     ],
-    "time": "2021-07-04",
     "repositories": [
         {
-            "type": "composer",
-            "url": "https://horde-satis.maintaina.com/"
+            "type": "path",
+            "url": "../Jwt"
+        },
+        {
+            "type": "path",
+            "url": "../Http"
         }
     ],
     "require": {
-        "php": "^7",
-        "horde/exception": "^3 || dev-FRAMEWORK_6_0",
-        "horde/http": "^3 || dev-FRAMEWORK_6_0",
-        "horde/util": "^3 || dev-FRAMEWORK_6_0",
+        "php": "^8.1",
+        "horde/jwt": "^1 || dev-FRAMEWORK_6_0",
+        "psr/http-message": "^2",
+        "psr/http-factory": "^1.0.2",
+        "psr/http-client": "^1.0.3",
+        "psr/http-server-handler": "^1.0.2",
+        "psr/http-server-middleware": "^1.0.2",
         "ext-hash": "*",
+        "ext-json": "*",
         "ext-openssl": "*"
     },
-    "require-dev": {},
-    "suggest": {},
+    "require-dev": {
+        "horde/http": "^3 || dev-FRAMEWORK_6_0",
+        "phpstan/phpstan": "^2.0"
+    },
+    "suggest": {
+        "horde/http": "PSR-7/17/18 implementation; also needed for legacy OAuth 1.0a in lib/",
+        "horde/exception": "Needed for legacy OAuth 1.0a classes in lib/",
+        "horde/util": "Needed for legacy OAuth 1.0a classes in lib/"
+    },
     "autoload": {
         "psr-0": {
             "Horde_Oauth": "lib/"
+        },
+        "psr-4": {
+            "Horde\\Oauth\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Horde\\Oauth\\Test\\": "test/"
         }
     }
 }

--- a/doc/examples/discover-provider-config.php
+++ b/doc/examples/discover-provider-config.php
@@ -1,0 +1,98 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Discover OAuth2/OIDC provider configuration from well-known endpoints.
+ *
+ * Fetches the OpenID Connect discovery document from a real provider
+ * and prints the key endpoints and capabilities.
+ *
+ * Usage:
+ *   php doc/examples/discover-provider-config.php [issuer-url]
+ *
+ * Examples:
+ *   php doc/examples/discover-provider-config.php
+ *   php doc/examples/discover-provider-config.php https://accounts.google.com
+ *   php doc/examples/discover-provider-config.php https://login.microsoftonline.com/common/v2.0
+ *   php doc/examples/discover-provider-config.php https://github.com
+ *
+ * Requires: composer install (horde/http must be available)
+ */
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Horde\Http\Client\Curl;
+use Horde\Http\Client\Options;
+use Horde\Http\RequestFactory;
+use Horde\Http\ResponseFactory;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Client\ProviderDiscovery;
+
+$issuer = $argv[1] ?? 'https://accounts.google.com';
+
+$discovery = new ProviderDiscovery(
+    new Curl(new ResponseFactory(), new StreamFactory(), new Options()),
+    new RequestFactory(),
+);
+
+echo "Discovering: {$issuer}\n";
+echo str_repeat('-', 60) . "\n\n";
+
+try {
+    $config = $discovery->discover($issuer);
+} catch (\Throwable $e) {
+    fwrite(STDERR, "Discovery failed: {$e->getMessage()}\n");
+    exit(1);
+}
+
+echo "Issuer:                 {$config->issuer}\n";
+echo "Authorization endpoint: {$config->authorizationEndpoint}\n";
+echo "Token endpoint:         {$config->tokenEndpoint}\n";
+echo "Userinfo endpoint:      " . ($config->userinfoEndpoint ?? '(not advertised)') . "\n";
+echo "JWKS URI:               " . ($config->jwksUri ?? '(not advertised)') . "\n";
+echo "Revocation endpoint:    " . ($config->revocationEndpoint ?? '(not advertised)') . "\n";
+echo "Introspection endpoint: " . ($config->introspectionEndpoint ?? '(not advertised)') . "\n";
+echo "\n";
+
+echo "Scopes supported:\n";
+if ($config->scopesSupported !== []) {
+    foreach ($config->scopesSupported as $scope) {
+        echo "  - {$scope}\n";
+    }
+} else {
+    echo "  (not advertised)\n";
+}
+echo "\n";
+
+echo "Response types supported:\n";
+foreach ($config->responseTypesSupported as $type) {
+    echo "  - {$type}\n";
+}
+echo "\n";
+
+echo "Grant types supported:\n";
+if ($config->grantTypesSupported !== []) {
+    foreach ($config->grantTypesSupported as $grant) {
+        echo "  - {$grant}\n";
+    }
+} else {
+    echo "  (not advertised)\n";
+}
+echo "\n";
+
+echo "Token endpoint auth methods:\n";
+foreach ($config->tokenEndpointAuthMethodsSupported as $method) {
+    echo "  - {$method}\n";
+}
+echo "\n";
+
+echo "ID token signing algorithms:\n";
+if ($config->idTokenSigningAlgValuesSupported !== []) {
+    foreach ($config->idTokenSigningAlgValuesSupported as $alg) {
+        echo "  - {$alg}\n";
+    }
+} else {
+    echo "  (not advertised)\n";
+}

--- a/lib/Horde/Oauth/Consumer.php
+++ b/lib/Horde/Oauth/Consumer.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -38,9 +39,9 @@ class Horde_Oauth_Consumer
     public function __construct($config)
     {
         // Check for required config
-        if (!is_array($config) || empty($config['key']) || empty($config['secret']) ||
-            empty($config['requestTokenUrl']) || empty($config['authorizeTokenUrl']) ||
-            empty($config['signatureMethod'])) {
+        if (!is_array($config) || empty($config['key']) || empty($config['secret'])
+            || empty($config['requestTokenUrl']) || empty($config['authorizeTokenUrl'])
+            || empty($config['signatureMethod'])) {
 
             throw new InvalidArgumentException('Missing a required parameter in Horde_Oauth_Consumer::__construct');
         }
@@ -49,7 +50,7 @@ class Horde_Oauth_Consumer
 
     public function __get($name)
     {
-        return isset($this->_config[$name]) ? $this->_config[$name] : null;
+        return $this->_config[$name] ?? null;
     }
 
     /**
@@ -59,7 +60,7 @@ class Horde_Oauth_Consumer
      *
      * @return Horde_Oauth_Token  The oauth request token
      */
-    public function getRequestToken($params = array())
+    public function getRequestToken($params = [])
     {
         $params['oauth_consumer_key'] = $this->key;
         $params['oauth_callback'] = $this->callbackUrl;
@@ -67,7 +68,7 @@ class Horde_Oauth_Consumer
         $request = new Horde_Oauth_Request($this->requestTokenUrl, $params);
         $request->sign($this->signatureMethod, $this);
 
-        $client = new Horde_Http_Client;
+        $client = new Horde_Http_Client();
 
         try {
             $response = $client->post(
@@ -104,7 +105,7 @@ class Horde_Oauth_Consumer
      *
      * @return unknown_type
      */
-    public function getAccessToken($token, $params = array())
+    public function getAccessToken($token, $params = [])
     {
         $params['oauth_consumer_key'] = $this->key;
         $params['oauth_token'] = $token->key;
@@ -112,7 +113,7 @@ class Horde_Oauth_Consumer
         $request = new Horde_Oauth_Request($this->accessTokenUrl, $params);
         $request->sign($this->signatureMethod, $this, $token);
 
-        $client = new Horde_Http_Client;
+        $client = new Horde_Http_Client();
         try {
             $response = $client->post(
                 $this->accessTokenUrl,

--- a/lib/Horde/Oauth/Exception.php
+++ b/lib/Horde/Oauth/Exception.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -16,6 +17,4 @@
  * @category Horde
  * @package  Oauth
  */
-class Horde_Oauth_Exception extends Horde_Exception_Wrapped
-{
-}
+class Horde_Oauth_Exception extends Horde_Exception_Wrapped {}

--- a/lib/Horde/Oauth/Request.php
+++ b/lib/Horde/Oauth/Request.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -18,13 +19,13 @@
  */
 class Horde_Oauth_Request
 {
-    const VERSION = '1.0';
+    public const VERSION = '1.0';
 
-    protected $_params = array();
+    protected $_params = [];
     protected $_url;
     protected $_method;
 
-    function __construct($url, $params = array(), $method = 'POST')
+    public function __construct($url, $params = [], $method = 'POST')
     {
         if (!isset($params['oauth_version'])) {
             $params['oauth_version'] = self::VERSION;
@@ -73,13 +74,13 @@ class Horde_Oauth_Request
      */
     public function getSignatureBaseString()
     {
-        $parts = array(
+        $parts = [
             $this->_getNormalizedHttpMethod(),
             $this->_getNormalizedUrl(),
-            $this->_getSignableParameters()
-        );
+            $this->_getSignableParameters(),
+        ];
 
-        return implode('&', array_map(array('Horde_Oauth_Utils', 'urlencodeRfc3986'), $parts));
+        return implode('&', array_map(['Horde_Oauth_Utils', 'urlencodeRfc3986'], $parts));
     }
 
     /**
@@ -87,7 +88,7 @@ class Horde_Oauth_Request
      */
     public function buildHttpQuery()
     {
-        $parts = array();
+        $parts = [];
         foreach ($this->_params as $k => $v) {
             $parts[] = Horde_Oauth_Utils::urlencodeRfc3986($k) . '=' . Horde_Oauth_Utils::urlencodeRfc3986($v);
         }
@@ -143,15 +144,15 @@ class Horde_Oauth_Request
         }
 
         // Urlencode both keys and values
-        $keys = array_map(array('Horde_Oauth_Utils', 'urlencodeRfc3986'), array_keys($params));
-        $values = array_map(array('Horde_Oauth_Utils', 'urlencodeRfc3986'), array_values($params));
+        $keys = array_map(['Horde_Oauth_Utils', 'urlencodeRfc3986'], array_keys($params));
+        $values = array_map(['Horde_Oauth_Utils', 'urlencodeRfc3986'], array_values($params));
         $params = array_combine($keys, $values);
 
         // Sort by keys (natsort)
         uksort($params, 'strnatcmp');
 
         // Generate key=value pairs
-        $pairs = array();
+        $pairs = [];
         foreach ($params as $key => $value) {
             if (is_array($value)) {
                 // If the value is an array, it's because there are multiple values
@@ -186,13 +187,13 @@ class Horde_Oauth_Request
         $scheme = $parts['scheme'];
         $port = !empty($parts['port'])
             ? $parts['port']
-            : $scheme == 'https' ? '443' : '80';
+            : ($scheme == 'https' ? '443' : '80');
 
         $host = $parts['host'];
         $path = !empty($parts['path']) ? $parts['path'] : '';
 
-        if (($scheme == 'https' && $port != '443') ||
-            ($scheme == 'http' && $port != '80')) {
+        if (($scheme == 'https' && $port != '443')
+            || ($scheme == 'http' && $port != '80')) {
             $host = "$host:$port";
         }
 

--- a/lib/Horde/Oauth/SignatureMethod.php
+++ b/lib/Horde/Oauth/SignatureMethod.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD

--- a/lib/Horde/Oauth/SignatureMethod/HmacSha1.php
+++ b/lib/Horde/Oauth/SignatureMethod/HmacSha1.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -27,12 +28,12 @@ class Horde_Oauth_SignatureMethod_HmacSha1 extends Horde_Oauth_SignatureMethod
     {
         $baseString = $request->getSignatureBaseString();
 
-        $key_parts = array(
+        $key_parts = [
             $consumer->secret,
-            ($token) ? $token->secret : ''
-        );
+            ($token) ? $token->secret : '',
+        ];
 
-        $key_parts = array_map(array('Horde_Oauth_Utils','urlencodeRfc3986'), $key_parts);
+        $key_parts = array_map(['Horde_Oauth_Utils','urlencodeRfc3986'], $key_parts);
         $key = implode('&', $key_parts);
 
         return base64_encode(hash_hmac('sha1', $baseString, $key, true));

--- a/lib/Horde/Oauth/SignatureMethod/Plaintext.php
+++ b/lib/Horde/Oauth/SignatureMethod/Plaintext.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -25,9 +26,9 @@ class Horde_Oauth_SignatureMethod_Plaintext extends Horde_Oauth_SignatureMethod
 
     public function sign($request, $consumer, $token)
     {
-        $signature = array(
+        $signature = [
             Horde_Oauth_Utils::urlencodeRfc3986($consumer->secret),
-        );
+        ];
 
         if ($token) {
             $signature[] = Horde_Oauth_Utils::urlencodeRfc3986($token->secret);

--- a/lib/Horde/Oauth/SignatureMethod/RsaSha1.php
+++ b/lib/Horde/Oauth/SignatureMethod/RsaSha1.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD

--- a/lib/Horde/Oauth/Token.php
+++ b/lib/Horde/Oauth/Token.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -25,7 +26,7 @@ class Horde_Oauth_Token
      * key = the token
      * secret = the token secret
      */
-    function __construct($key, $secret)
+    public function __construct($key, $secret)
     {
         $this->key = $key;
         $this->secret = $secret;
@@ -38,8 +39,8 @@ class Horde_Oauth_Token
     public function __toString()
     {
         return
-            'oauth_token='.Horde_Oauth_Utils::urlencodeRfc3986($this->key).
-            '&oauth_token_secret='.Horde_Oauth_Utils::urlencodeRfc3986($this->secret);
+            'oauth_token=' . Horde_Oauth_Utils::urlencodeRfc3986($this->key)
+            . '&oauth_token_secret=' . Horde_Oauth_Utils::urlencodeRfc3986($this->secret);
     }
 
     public static function fromString($string)

--- a/lib/Horde/Oauth/Utils.php
+++ b/lib/Horde/Oauth/Utils.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- * Copyright 2008-2017 Horde LLC (http://www.horde.org/)
+ * Copyright 2008-2026 Horde LLC (http://www.horde.org/)
  *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @license  http://www.horde.org/licenses/bsd BSD
@@ -20,9 +21,11 @@ class Horde_Oauth_Utils
 {
     public static function urlencodeRfc3986($string)
     {
-        return str_replace(array('%7E', '+'),
-                           array('~', '%2B'),
-                           rawurlencode($string));
+        return str_replace(
+            ['%7E', '+'],
+            ['~', '%2B'],
+            rawurlencode($string)
+        );
     }
 
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         beStrictAboutOutputDuringTests="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="OAuth2 Test Suite">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+    <coverage/>
+</phpunit>

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Client;
+
+use Horde\Oauth\Exception\OAuthException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class OAuth2Client
+{
+    public function __construct(
+        private readonly ProviderConfig $provider,
+        private readonly string $clientId,
+        private readonly ?string $clientSecret,
+        private readonly string $redirectUri,
+        private readonly ClientInterface $httpClient,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    /**
+     * @param string[] $scopes
+     * @param array<string, string> $extraParams
+     */
+    public function getAuthorizationUrl(
+        array $scopes = [],
+        ?string $state = null,
+        ?string $nonce = null,
+        ?string $codeChallenge = null,
+        ?string $codeChallengeMethod = null,
+        array $extraParams = [],
+    ): string {
+        $params = [
+            'response_type' => 'code',
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->redirectUri,
+        ];
+
+        if ($scopes !== []) {
+            $params['scope'] = implode(' ', $scopes);
+        }
+        if ($state !== null) {
+            $params['state'] = $state;
+        }
+        if ($nonce !== null) {
+            $params['nonce'] = $nonce;
+        }
+        if ($codeChallenge !== null) {
+            $params['code_challenge'] = $codeChallenge;
+            $params['code_challenge_method'] = $codeChallengeMethod ?? 'S256';
+        }
+
+        $params = array_merge($params, $extraParams);
+
+        return $this->provider->authorizationEndpoint . '?' . http_build_query($params);
+    }
+
+    public function exchangeCode(string $code, ?string $codeVerifier = null): TokenSet
+    {
+        $params = [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $this->redirectUri,
+        ];
+
+        if ($codeVerifier !== null) {
+            $params['code_verifier'] = $codeVerifier;
+        }
+
+        if ($this->clientSecret === null) {
+            $params['client_id'] = $this->clientId;
+        }
+
+        return $this->tokenRequest($params);
+    }
+
+    public function refreshToken(string $refreshToken, ?string $scope = null): TokenSet
+    {
+        $refresher = new TokenRefresher(
+            $this->httpClient,
+            $this->requestFactory,
+            $this->streamFactory,
+            $this->provider->tokenEndpoint,
+            $this->clientId,
+            $this->clientSecret,
+        );
+
+        return $refresher->refresh($refreshToken, $scope);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function fetchUserinfo(string $accessToken): array
+    {
+        if ($this->provider->userinfoEndpoint === null) {
+            throw new OAuthException('invalid_request', 'Provider does not support a userinfo endpoint');
+        }
+
+        $request = $this->requestFactory->createRequest('GET', $this->provider->userinfoEndpoint)
+            ->withHeader('Authorization', 'Bearer ' . $accessToken)
+            ->withHeader('Accept', 'application/json');
+
+        $response = $this->httpClient->sendRequest($request);
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            throw new OAuthException('invalid_request', 'Userinfo endpoint returned invalid response');
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function tokenRequest(array $params): TokenSet
+    {
+        $body = $this->streamFactory->createStream(http_build_query($params));
+
+        $request = $this->requestFactory->createRequest('POST', $this->provider->tokenEndpoint)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($body);
+
+        if ($this->clientSecret !== null) {
+            $credentials = base64_encode(urlencode($this->clientId) . ':' . urlencode($this->clientSecret));
+            $request = $request->withHeader('Authorization', 'Basic ' . $credentials);
+        }
+
+        $response = $this->httpClient->sendRequest($request);
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            throw new OAuthException('invalid_request', 'Token endpoint returned invalid response');
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            throw new OAuthException(
+                $data['error'] ?? 'server_error',
+                $data['error_description'] ?? 'Token request failed',
+            );
+        }
+
+        return TokenSet::fromArray($data);
+    }
+}

--- a/src/Client/PkceGenerator.php
+++ b/src/Client/PkceGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Client;
+
+use Horde\Jwt\Base64Url;
+
+final class PkceGenerator
+{
+    public static function generateVerifier(int $length = 128): string
+    {
+        $length = max(43, min(128, $length));
+        $bytes = random_bytes((int) ceil($length * 3 / 4));
+        return substr(Base64Url::encode($bytes), 0, $length);
+    }
+
+    public static function computeChallenge(string $verifier, string $method = 'S256'): string
+    {
+        if ($method === 'plain') {
+            return $verifier;
+        }
+
+        return Base64Url::encode(hash('sha256', $verifier, true));
+    }
+}

--- a/src/Client/ProviderConfig.php
+++ b/src/Client/ProviderConfig.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Client;
+
+final class ProviderConfig
+{
+    /**
+     * @param string[] $scopesSupported
+     * @param string[] $responseTypesSupported
+     * @param string[] $grantTypesSupported
+     * @param string[] $tokenEndpointAuthMethodsSupported
+     * @param string[] $idTokenSigningAlgValuesSupported
+     */
+    public function __construct(
+        public readonly string $issuer,
+        public readonly string $authorizationEndpoint,
+        public readonly string $tokenEndpoint,
+        public readonly ?string $userinfoEndpoint = null,
+        public readonly ?string $jwksUri = null,
+        public readonly ?string $revocationEndpoint = null,
+        public readonly ?string $introspectionEndpoint = null,
+        public readonly array $scopesSupported = [],
+        public readonly array $responseTypesSupported = ['code'],
+        public readonly array $grantTypesSupported = [],
+        public readonly array $tokenEndpointAuthMethodsSupported = ['client_secret_basic'],
+        public readonly array $idTokenSigningAlgValuesSupported = [],
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            issuer: (string) ($data['issuer'] ?? ''),
+            authorizationEndpoint: (string) ($data['authorization_endpoint'] ?? ''),
+            tokenEndpoint: (string) ($data['token_endpoint'] ?? ''),
+            userinfoEndpoint: isset($data['userinfo_endpoint']) ? (string) $data['userinfo_endpoint'] : null,
+            jwksUri: isset($data['jwks_uri']) ? (string) $data['jwks_uri'] : null,
+            revocationEndpoint: isset($data['revocation_endpoint']) ? (string) $data['revocation_endpoint'] : null,
+            introspectionEndpoint: isset($data['introspection_endpoint']) ? (string) $data['introspection_endpoint'] : null,
+            scopesSupported: (array) ($data['scopes_supported'] ?? []),
+            responseTypesSupported: (array) ($data['response_types_supported'] ?? ['code']),
+            grantTypesSupported: (array) ($data['grant_types_supported'] ?? []),
+            tokenEndpointAuthMethodsSupported: (array) ($data['token_endpoint_auth_methods_supported'] ?? ['client_secret_basic']),
+            idTokenSigningAlgValuesSupported: (array) ($data['id_token_signing_alg_values_supported'] ?? []),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'issuer' => $this->issuer,
+            'authorization_endpoint' => $this->authorizationEndpoint,
+            'token_endpoint' => $this->tokenEndpoint,
+            'userinfo_endpoint' => $this->userinfoEndpoint,
+            'jwks_uri' => $this->jwksUri,
+            'revocation_endpoint' => $this->revocationEndpoint,
+            'introspection_endpoint' => $this->introspectionEndpoint,
+            'scopes_supported' => $this->scopesSupported,
+            'response_types_supported' => $this->responseTypesSupported,
+            'grant_types_supported' => $this->grantTypesSupported,
+            'token_endpoint_auth_methods_supported' => $this->tokenEndpointAuthMethodsSupported,
+            'id_token_signing_alg_values_supported' => $this->idTokenSigningAlgValuesSupported,
+        ], static fn($v) => $v !== null && $v !== []);
+    }
+}

--- a/src/Client/ProviderDiscovery.php
+++ b/src/Client/ProviderDiscovery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Client;
+
+use Horde\Oauth\Exception\OAuthException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+
+final class ProviderDiscovery
+{
+    public function __construct(
+        private readonly ClientInterface $httpClient,
+        private readonly RequestFactoryInterface $requestFactory,
+    ) {}
+
+    public function discover(string $issuerUrl): ProviderConfig
+    {
+        $issuerUrl = rtrim($issuerUrl, '/');
+
+        $urls = [
+            $issuerUrl . '/.well-known/openid-configuration',
+            $issuerUrl . '/.well-known/oauth-authorization-server',
+        ];
+
+        foreach ($urls as $url) {
+            $request = $this->requestFactory->createRequest('GET', $url)
+                ->withHeader('Accept', 'application/json');
+
+            $response = $this->httpClient->sendRequest($request);
+
+            if ($response->getStatusCode() === 200) {
+                $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+                if (!is_array($data)) {
+                    throw new OAuthException('invalid_request', 'Discovery document is not a JSON object');
+                }
+                return ProviderConfig::fromArray($data);
+            }
+        }
+
+        throw new OAuthException('invalid_request', "Failed to discover provider at {$issuerUrl}");
+    }
+}

--- a/src/Client/TokenRefresher.php
+++ b/src/Client/TokenRefresher.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Client;
+
+use Horde\Oauth\Exception\OAuthException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class TokenRefresher
+{
+    public function __construct(
+        private readonly ClientInterface $httpClient,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly string $tokenEndpoint,
+        private readonly string $clientId,
+        private readonly ?string $clientSecret = null,
+    ) {}
+
+    public function refresh(string $refreshToken, ?string $scope = null): TokenSet
+    {
+        $params = [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refreshToken,
+        ];
+
+        if ($scope !== null) {
+            $params['scope'] = $scope;
+        }
+
+        if ($this->clientSecret === null) {
+            $params['client_id'] = $this->clientId;
+        }
+
+        $body = $this->streamFactory->createStream(http_build_query($params));
+
+        $request = $this->requestFactory->createRequest('POST', $this->tokenEndpoint)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($body);
+
+        if ($this->clientSecret !== null) {
+            $credentials = base64_encode(urlencode($this->clientId) . ':' . urlencode($this->clientSecret));
+            $request = $request->withHeader('Authorization', 'Basic ' . $credentials);
+        }
+
+        $response = $this->httpClient->sendRequest($request);
+        $data = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data)) {
+            throw new OAuthException('invalid_request', 'Token endpoint returned invalid response');
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            throw new OAuthException(
+                $data['error'] ?? 'server_error',
+                $data['error_description'] ?? 'Token refresh failed',
+            );
+        }
+
+        return TokenSet::fromArray($data);
+    }
+}

--- a/src/Client/TokenSet.php
+++ b/src/Client/TokenSet.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Client;
+
+final class TokenSet
+{
+    public function __construct(
+        public readonly string $accessToken,
+        public readonly string $tokenType,
+        public readonly ?int $expiresIn = null,
+        public readonly ?string $refreshToken = null,
+        public readonly ?string $scope = null,
+        public readonly ?string $idToken = null,
+        public readonly ?int $receivedAt = null,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            accessToken: (string) ($data['access_token'] ?? ''),
+            tokenType: (string) ($data['token_type'] ?? 'Bearer'),
+            expiresIn: isset($data['expires_in']) ? (int) $data['expires_in'] : null,
+            refreshToken: isset($data['refresh_token']) ? (string) $data['refresh_token'] : null,
+            scope: isset($data['scope']) ? (string) $data['scope'] : null,
+            idToken: isset($data['id_token']) ? (string) $data['id_token'] : null,
+            receivedAt: time(),
+        );
+    }
+
+    public function isExpired(int $leeway = 30): bool
+    {
+        $expiresAt = $this->getExpiresAt();
+        if ($expiresAt === null) {
+            return false;
+        }
+
+        return time() >= ($expiresAt - $leeway);
+    }
+
+    public function getExpiresAt(): ?int
+    {
+        if ($this->expiresIn === null || $this->receivedAt === null) {
+            return null;
+        }
+
+        return $this->receivedAt + $this->expiresIn;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'access_token' => $this->accessToken,
+            'token_type' => $this->tokenType,
+            'expires_in' => $this->expiresIn,
+            'refresh_token' => $this->refreshToken,
+            'scope' => $this->scope,
+            'id_token' => $this->idToken,
+        ], static fn($v) => $v !== null);
+    }
+}

--- a/src/ErrorResponse.php
+++ b/src/ErrorResponse.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth;
+
+use Horde\Oauth\Exception\OAuthException;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class ErrorResponse
+{
+    /**
+     * @return array<string, string>
+     */
+    public static function toArray(OAuthException $e): array
+    {
+        $data = ['error' => $e->getError()];
+
+        if ($e->getErrorDescription() !== '') {
+            $data['error_description'] = $e->getErrorDescription();
+        }
+
+        if ($e->getErrorUri() !== '') {
+            $data['error_uri'] = $e->getErrorUri();
+        }
+
+        return $data;
+    }
+
+    public static function toJson(OAuthException $e): string
+    {
+        return json_encode(self::toArray($e), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    public static function toResponse(
+        OAuthException $e,
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory,
+    ): ResponseInterface {
+        $body = $streamFactory->createStream(self::toJson($e));
+
+        return $responseFactory->createResponse($e->getHttpStatusCode())
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withHeader('Cache-Control', 'no-store')
+            ->withHeader('Pragma', 'no-cache')
+            ->withBody($body);
+    }
+}

--- a/src/Exception/AccessDeniedException.php
+++ b/src/Exception/AccessDeniedException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class AccessDeniedException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('access_denied', $errorDescription, $errorUri, 403, $previous);
     }

--- a/src/Exception/AccessDeniedException.php
+++ b/src/Exception/AccessDeniedException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class AccessDeniedException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('access_denied', $errorDescription, $errorUri, 403, $previous);
+    }
+}

--- a/src/Exception/InvalidClientException.php
+++ b/src/Exception/InvalidClientException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class InvalidClientException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('invalid_client', $errorDescription, $errorUri, 401, $previous);
     }

--- a/src/Exception/InvalidClientException.php
+++ b/src/Exception/InvalidClientException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class InvalidClientException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('invalid_client', $errorDescription, $errorUri, 401, $previous);
+    }
+}

--- a/src/Exception/InvalidGrantException.php
+++ b/src/Exception/InvalidGrantException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class InvalidGrantException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('invalid_grant', $errorDescription, $errorUri, 400, $previous);
+    }
+}

--- a/src/Exception/InvalidGrantException.php
+++ b/src/Exception/InvalidGrantException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class InvalidGrantException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('invalid_grant', $errorDescription, $errorUri, 400, $previous);
     }

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class InvalidRequestException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('invalid_request', $errorDescription, $errorUri, 400, $previous);
     }

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class InvalidRequestException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('invalid_request', $errorDescription, $errorUri, 400, $previous);
+    }
+}

--- a/src/Exception/InvalidScopeException.php
+++ b/src/Exception/InvalidScopeException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class InvalidScopeException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('invalid_scope', $errorDescription, $errorUri, 400, $previous);
     }

--- a/src/Exception/InvalidScopeException.php
+++ b/src/Exception/InvalidScopeException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class InvalidScopeException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('invalid_scope', $errorDescription, $errorUri, 400, $previous);
+    }
+}

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+class OAuthException extends \RuntimeException
+{
+    public function __construct(
+        private readonly string $error,
+        string $errorDescription = '',
+        private readonly string $errorUri = '',
+        private readonly int $httpStatusCode = 400,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($errorDescription, 0, $previous);
+    }
+
+    public function getError(): string
+    {
+        return $this->error;
+    }
+
+    public function getErrorDescription(): string
+    {
+        return $this->getMessage();
+    }
+
+    public function getErrorUri(): string
+    {
+        return $this->errorUri;
+    }
+
+    public function getHttpStatusCode(): int
+    {
+        return $this->httpStatusCode;
+    }
+}

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -13,14 +13,17 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
-class OAuthException extends \RuntimeException
+use RuntimeException;
+use Throwable;
+
+class OAuthException extends RuntimeException
 {
     public function __construct(
         private readonly string $error,
         string $errorDescription = '',
         private readonly string $errorUri = '',
         private readonly int $httpStatusCode = 400,
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct($errorDescription, 0, $previous);
     }

--- a/src/Exception/UnauthorizedClientException.php
+++ b/src/Exception/UnauthorizedClientException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class UnauthorizedClientException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('unauthorized_client', $errorDescription, $errorUri, 400, $previous);
     }

--- a/src/Exception/UnauthorizedClientException.php
+++ b/src/Exception/UnauthorizedClientException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class UnauthorizedClientException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('unauthorized_client', $errorDescription, $errorUri, 400, $previous);
+    }
+}

--- a/src/Exception/UnsupportedGrantTypeException.php
+++ b/src/Exception/UnsupportedGrantTypeException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Exception;
+
+final class UnsupportedGrantTypeException extends OAuthException
+{
+    public function __construct(
+        string $errorDescription = '',
+        string $errorUri = '',
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct('unsupported_grant_type', $errorDescription, $errorUri, 400, $previous);
+    }
+}

--- a/src/Exception/UnsupportedGrantTypeException.php
+++ b/src/Exception/UnsupportedGrantTypeException.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Exception;
 
+use Throwable;
+
 final class UnsupportedGrantTypeException extends OAuthException
 {
     public function __construct(
         string $errorDescription = '',
         string $errorUri = '',
-        ?\Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct('unsupported_grant_type', $errorDescription, $errorUri, 400, $previous);
     }

--- a/src/Oidc/ClaimsMapper.php
+++ b/src/Oidc/ClaimsMapper.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc;
+
+interface ClaimsMapper
+{
+    /**
+     * @param string[] $claimNames
+     * @return array<string, mixed>
+     */
+    public function getClaims(string $identityId, array $claimNames): array;
+}

--- a/src/Oidc/Handler/DiscoveryEndpoint.php
+++ b/src/Oidc/Handler/DiscoveryEndpoint.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc\Handler;
+
+use Horde\Oauth\Server\ServerMetadata;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DiscoveryEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly ServerMetadata $metadata,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = $this->streamFactory->createStream($this->metadata->toJson());
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withBody($body);
+    }
+}

--- a/src/Oidc/Handler/JwksEndpoint.php
+++ b/src/Oidc/Handler/JwksEndpoint.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc\Handler;
+
+use Horde\Jwt\Key\Jwk;
+use Horde\Jwt\Key\PublicKey;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class JwksEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly PublicKey $publicKey,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly string $keyId = 'default',
+        private readonly string $algorithm = 'RS256',
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $jwk = Jwk::fromPublicKey($this->publicKey);
+        $jwk['kid'] = $this->keyId;
+        $jwk['alg'] = $this->algorithm;
+
+        $json = json_encode(['keys' => [$jwk]], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        $body = $this->streamFactory->createStream($json);
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withBody($body);
+    }
+}

--- a/src/Oidc/Handler/UserinfoEndpoint.php
+++ b/src/Oidc/Handler/UserinfoEndpoint.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc\Handler;
+
+use Horde\Oauth\Oidc\ClaimsMapper;
+use Horde\Oauth\Oidc\ScopeClaimsMapping;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UserinfoEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly ClaimsMapper $claimsMapper,
+        private readonly ScopeClaimsMapping $scopeMapping,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $identityId = $request->getAttribute('oauth_user_id');
+        $scopeString = $request->getAttribute('oauth_scopes', '');
+
+        if (!is_string($identityId) || $identityId === '') {
+            $body = $this->streamFactory->createStream(json_encode([
+                'error' => 'invalid_token',
+                'error_description' => 'Access token required',
+            ], JSON_THROW_ON_ERROR));
+
+            return $this->responseFactory->createResponse(401)
+                ->withHeader('WWW-Authenticate', 'Bearer')
+                ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+                ->withBody($body);
+        }
+
+        $scopes = is_string($scopeString) ? array_filter(explode(' ', $scopeString)) : [];
+        $claimNames = $this->scopeMapping->getClaimsForScopes($scopes);
+        $claims = $this->claimsMapper->getClaims($identityId, $claimNames);
+
+        $claims['sub'] = $identityId;
+
+        $json = json_encode($claims, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        $body = $this->streamFactory->createStream($json);
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withBody($body);
+    }
+}

--- a/src/Oidc/IdTokenBuilder.php
+++ b/src/Oidc/IdTokenBuilder.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc;
+
+use Horde\Jwt\Base64Url;
+use Horde\Jwt\Signer\SignerInterface;
+use Horde\Jwt\TokenEncoder;
+
+final class IdTokenBuilder
+{
+    public function __construct(
+        private readonly TokenEncoder $encoder,
+        private readonly SignerInterface $signer,
+        private readonly ClaimsMapper $claimsMapper,
+        private readonly ScopeClaimsMapping $scopeMapping,
+        private readonly string $issuer,
+        private readonly int $ttl = 3600,
+    ) {}
+
+    /**
+     * @param string[] $scopes
+     */
+    public function build(
+        string $identityId,
+        string $clientId,
+        array $scopes,
+        ?string $nonce = null,
+        ?string $accessTokenHash = null,
+        ?string $codeHash = null,
+    ): string {
+        $claimNames = $this->scopeMapping->getClaimsForScopes($scopes);
+        $userClaims = $this->claimsMapper->getClaims($identityId, $claimNames);
+
+        $claims = [
+            'iss' => $this->issuer,
+            'sub' => $identityId,
+            'aud' => $clientId,
+            'auth_time' => time(),
+        ];
+
+        if ($nonce !== null) {
+            $claims['nonce'] = $nonce;
+        }
+
+        if ($accessTokenHash !== null) {
+            $claims['at_hash'] = $accessTokenHash;
+        }
+
+        if ($codeHash !== null) {
+            $claims['c_hash'] = $codeHash;
+        }
+
+        $claims = array_merge($claims, $userClaims);
+
+        $token = $this->encoder->encode($claims, $this->signer, $this->ttl);
+
+        return $token->toString();
+    }
+
+    public static function computeAtHash(string $accessToken, string $algorithm = 'RS256'): string
+    {
+        $hashAlg = match ($algorithm) {
+            'RS256', 'ES256', 'HS256' => 'sha256',
+            default => 'sha256',
+        };
+
+        $hash = hash($hashAlg, $accessToken, true);
+        $leftHalf = substr($hash, 0, (int) (strlen($hash) / 2));
+
+        return Base64Url::encode($leftHalf);
+    }
+}

--- a/src/Oidc/OidcServer.php
+++ b/src/Oidc/OidcServer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc;
+
+use Horde\Jwt\Key\PublicKey;
+use Horde\Jwt\Signer\SignerInterface;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Oidc\Handler\DiscoveryEndpoint;
+use Horde\Oauth\Oidc\Handler\JwksEndpoint;
+use Horde\Oauth\Oidc\Handler\UserinfoEndpoint;
+use Horde\Oauth\Server\AuthorizationServer;
+use Horde\Oauth\Server\ServerMetadata;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class OidcServer
+{
+    public function __construct(
+        private readonly AuthorizationServer $server,
+        private readonly IdTokenBuilder $idTokenBuilder,
+        private readonly ClaimsMapper $claimsMapper,
+        private readonly ScopeClaimsMapping $scopeMapping,
+        private readonly PublicKey $publicKey,
+        private readonly ServerMetadata $metadata,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function getDiscoveryEndpoint(): DiscoveryEndpoint
+    {
+        return new DiscoveryEndpoint(
+            $this->metadata,
+            $this->responseFactory,
+            $this->streamFactory,
+        );
+    }
+
+    public function getJwksEndpoint(string $keyId = 'default'): JwksEndpoint
+    {
+        return new JwksEndpoint(
+            $this->publicKey,
+            $this->responseFactory,
+            $this->streamFactory,
+            $keyId,
+        );
+    }
+
+    public function getUserinfoEndpoint(): UserinfoEndpoint
+    {
+        return new UserinfoEndpoint(
+            $this->claimsMapper,
+            $this->scopeMapping,
+            $this->responseFactory,
+            $this->streamFactory,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $tokenResponse
+     * @param string[] $scopes
+     * @return array<string, mixed>
+     */
+    public function wrapTokenResponse(
+        array $tokenResponse,
+        string $identityId,
+        string $clientId,
+        array $scopes,
+        ?string $nonce = null,
+    ): array {
+        if (!in_array('openid', $scopes, true)) {
+            return $tokenResponse;
+        }
+
+        $accessToken = $tokenResponse['access_token'] ?? '';
+        $atHash = is_string($accessToken) ? IdTokenBuilder::computeAtHash($accessToken) : null;
+
+        $tokenResponse['id_token'] = $this->idTokenBuilder->build(
+            $identityId,
+            $clientId,
+            $scopes,
+            $nonce,
+            $atHash,
+        );
+
+        return $tokenResponse;
+    }
+}

--- a/src/Oidc/ScopeClaimsMapping.php
+++ b/src/Oidc/ScopeClaimsMapping.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Oidc;
+
+final class ScopeClaimsMapping
+{
+    private const DEFAULTS = [
+        'profile' => [
+            'name', 'family_name', 'given_name', 'middle_name', 'nickname',
+            'preferred_username', 'profile', 'picture', 'website',
+            'gender', 'birthdate', 'zoneinfo', 'locale', 'updated_at',
+        ],
+        'email' => ['email', 'email_verified'],
+        'address' => ['address'],
+        'phone' => ['phone_number', 'phone_number_verified'],
+    ];
+
+    /** @var array<string, string[]> */
+    private readonly array $mapping;
+
+    /**
+     * @param array<string, string[]> $mapping
+     */
+    public function __construct(array $mapping = [])
+    {
+        $this->mapping = $mapping !== [] ? $mapping : self::DEFAULTS;
+    }
+
+    /**
+     * @param string[] $scopes
+     * @return string[]
+     */
+    public function getClaimsForScopes(array $scopes): array
+    {
+        $claims = [];
+        foreach ($scopes as $scope) {
+            if (isset($this->mapping[$scope])) {
+                $claims = array_merge($claims, $this->mapping[$scope]);
+            }
+        }
+        return array_unique($claims);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getScopesForClaim(string $claim): array
+    {
+        $scopes = [];
+        foreach ($this->mapping as $scope => $claims) {
+            if (in_array($claim, $claims, true)) {
+                $scopes[] = $scope;
+            }
+        }
+        return $scopes;
+    }
+}

--- a/src/Server/AuthorizationRequest.php
+++ b/src/Server/AuthorizationRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+
+final class AuthorizationRequest
+{
+    /**
+     * @param Scope[] $scopes
+     */
+    public function __construct(
+        public readonly Client $client,
+        public readonly string $responseType,
+        public readonly string $redirectUri,
+        public readonly string $state,
+        public readonly array $scopes,
+        public readonly ?string $codeChallenge,
+        public readonly ?string $codeChallengeMethod,
+        public readonly ?string $nonce,
+    ) {}
+}

--- a/src/Server/AuthorizationResult.php
+++ b/src/Server/AuthorizationResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server;
+
+use Horde\Oauth\Server\Entity\Scope;
+
+final class AuthorizationResult
+{
+    /**
+     * @param Scope[]|null $approvedScopes
+     */
+    public function __construct(
+        public readonly AuthorizationRequest $request,
+        public readonly bool $approved,
+        public readonly ?string $identityId,
+        public readonly ?array $approvedScopes = null,
+    ) {}
+}

--- a/src/Server/AuthorizationServer.php
+++ b/src/Server/AuthorizationServer.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server;
+
+use Horde\Jwt\Signer\SignerInterface;
+use Horde\Jwt\TokenDecoder;
+use Horde\Jwt\TokenEncoder;
+use Horde\Jwt\Verifier\VerifierInterface;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretBasic;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretPost;
+use Horde\Oauth\Server\Grant\AuthorizationCodeGrant;
+use Horde\Oauth\Server\Grant\ClientCredentialsGrant;
+use Horde\Oauth\Server\Grant\Grant;
+use Horde\Oauth\Server\Grant\RefreshTokenGrant;
+use Horde\Oauth\Server\Handler\AuthorizationEndpoint;
+use Horde\Oauth\Server\Handler\IntrospectionEndpoint;
+use Horde\Oauth\Server\Handler\MetadataEndpoint;
+use Horde\Oauth\Server\Handler\RevocationEndpoint;
+use Horde\Oauth\Server\Handler\TokenEndpoint;
+use Horde\Oauth\Server\Middleware\BearerTokenMiddleware;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+use Horde\Oauth\Server\Repository\AuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\ClientRepository;
+use Horde\Oauth\Server\Repository\ConsentRepository;
+use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+use Horde\Oauth\Server\Repository\ScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Server\Token\RefreshTokenIssuer;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+final class AuthorizationServer
+{
+    /** @var array<string, Grant> */
+    private array $grants = [];
+
+    public function __construct(
+        private readonly ClientRepository $clientRepository,
+        private readonly AccessTokenRepository $accessTokenRepository,
+        private readonly RefreshTokenRepository $refreshTokenRepository,
+        private readonly AuthorizationCodeRepository $authCodeRepository,
+        private readonly ScopeRepository $scopeRepository,
+        private readonly ConsentRepository $consentRepository,
+        private readonly TokenEncoder $tokenEncoder,
+        private readonly SignerInterface $signer,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly ServerMetadata $metadata,
+    ) {}
+
+    public function enableGrant(Grant $grant): void
+    {
+        $this->grants[$grant->getIdentifier()] = $grant;
+    }
+
+    public function getTokenEndpoint(): TokenEndpoint
+    {
+        return new TokenEndpoint(
+            $this->buildClientAuthenticator(),
+            $this->responseFactory,
+            $this->streamFactory,
+            ...array_values($this->grants),
+        );
+    }
+
+    public function getAuthorizationEndpoint(): AuthorizationEndpoint
+    {
+        return new AuthorizationEndpoint(
+            $this->clientRepository,
+            $this->scopeRepository,
+            $this->authCodeRepository,
+            $this->responseFactory,
+            $this->streamFactory,
+        );
+    }
+
+    public function getRevocationEndpoint(): RevocationEndpoint
+    {
+        return new RevocationEndpoint(
+            $this->buildClientAuthenticator(),
+            $this->accessTokenRepository,
+            $this->refreshTokenRepository,
+            $this->responseFactory,
+            $this->streamFactory,
+        );
+    }
+
+    public function getIntrospectionEndpoint(): IntrospectionEndpoint
+    {
+        return new IntrospectionEndpoint(
+            $this->buildClientAuthenticator(),
+            $this->accessTokenRepository,
+            $this->refreshTokenRepository,
+            $this->responseFactory,
+            $this->streamFactory,
+        );
+    }
+
+    public function getMetadataEndpoint(): MetadataEndpoint
+    {
+        return new MetadataEndpoint(
+            $this->metadata,
+            $this->responseFactory,
+            $this->streamFactory,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function getBearerMiddleware(VerifierInterface $verifier, array $options = []): BearerTokenMiddleware
+    {
+        return new BearerTokenMiddleware(
+            new TokenDecoder(),
+            $verifier,
+            $this->accessTokenRepository,
+            $this->responseFactory,
+            $this->streamFactory,
+            required: (bool) ($options['required'] ?? true),
+            verifyOptions: $options['verify'] ?? [],
+        );
+    }
+
+    public function createAccessTokenIssuer(int $ttl = 3600): AccessTokenIssuer
+    {
+        return new AccessTokenIssuer(
+            $this->tokenEncoder,
+            $this->signer,
+            $this->accessTokenRepository,
+            $this->metadata->issuer,
+            $ttl,
+        );
+    }
+
+    public function createRefreshTokenIssuer(int $ttl = 2592000): RefreshTokenIssuer
+    {
+        return new RefreshTokenIssuer(
+            $this->refreshTokenRepository,
+            $ttl,
+        );
+    }
+
+    public function createAuthorizationCodeGrant(bool $issueRefreshTokens = true): AuthorizationCodeGrant
+    {
+        return new AuthorizationCodeGrant(
+            $this->authCodeRepository,
+            $this->createAccessTokenIssuer(),
+            $issueRefreshTokens ? $this->createRefreshTokenIssuer() : null,
+            $this->scopeRepository,
+        );
+    }
+
+    public function createClientCredentialsGrant(): ClientCredentialsGrant
+    {
+        return new ClientCredentialsGrant(
+            $this->createAccessTokenIssuer(),
+            $this->scopeRepository,
+        );
+    }
+
+    public function createRefreshTokenGrant(bool $issueRefreshTokens = true): RefreshTokenGrant
+    {
+        return new RefreshTokenGrant(
+            $this->refreshTokenRepository,
+            $this->accessTokenRepository,
+            $this->createAccessTokenIssuer(),
+            $issueRefreshTokens ? $this->createRefreshTokenIssuer() : null,
+            $this->scopeRepository,
+        );
+    }
+
+    private function buildClientAuthenticator(): ClientAuthenticatorChain
+    {
+        return new ClientAuthenticatorChain(
+            $this->clientRepository,
+            new ClientSecretBasic(),
+            new ClientSecretPost(),
+        );
+    }
+}

--- a/src/Server/ClientAuthentication/ClientAuthenticator.php
+++ b/src/Server/ClientAuthentication/ClientAuthenticator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\ClientAuthentication;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface ClientAuthenticator
+{
+    /**
+     * @return array{0: string, 1: ?string}|null [clientId, clientSecret] or null if not applicable
+     */
+    public function authenticate(ServerRequestInterface $request): ?array;
+
+    public function getMethod(): string;
+}

--- a/src/Server/ClientAuthentication/ClientAuthenticatorChain.php
+++ b/src/Server/ClientAuthentication/ClientAuthenticatorChain.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\ClientAuthentication;
+
+use Horde\Oauth\Exception\InvalidClientException;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Repository\ClientRepository;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ClientAuthenticatorChain
+{
+    /** @var ClientAuthenticator[] */
+    private readonly array $authenticators;
+
+    public function __construct(
+        private readonly ClientRepository $clientRepository,
+        ClientAuthenticator ...$authenticators,
+    ) {
+        $this->authenticators = $authenticators;
+    }
+
+    public function authenticateClient(ServerRequestInterface $request): Client
+    {
+        foreach ($this->authenticators as $authenticator) {
+            $result = $authenticator->authenticate($request);
+            if ($result === null) {
+                continue;
+            }
+
+            [$clientId, $clientSecret] = $result;
+
+            $client = $this->clientRepository->findById($clientId);
+            if ($client === null) {
+                throw new InvalidClientException('Unknown client');
+            }
+
+            if ($client->tokenEndpointAuthMethod !== $authenticator->getMethod()) {
+                throw new InvalidClientException('Invalid authentication method for this client');
+            }
+
+            if ($client->isConfidential()) {
+                if ($clientSecret === null || !$client->verifySecret($clientSecret)) {
+                    throw new InvalidClientException('Invalid client credentials');
+                }
+            }
+
+            return $client;
+        }
+
+        throw new InvalidClientException('No client authentication provided');
+    }
+
+    public function authenticateClientOrPublic(ServerRequestInterface $request): Client
+    {
+        foreach ($this->authenticators as $authenticator) {
+            $result = $authenticator->authenticate($request);
+            if ($result === null) {
+                continue;
+            }
+
+            [$clientId, $clientSecret] = $result;
+
+            $client = $this->clientRepository->findById($clientId);
+            if ($client === null) {
+                throw new InvalidClientException('Unknown client');
+            }
+
+            if ($client->isConfidential()) {
+                if ($clientSecret === null || !$client->verifySecret($clientSecret)) {
+                    throw new InvalidClientException('Invalid client credentials');
+                }
+            }
+
+            return $client;
+        }
+
+        $body = $request->getParsedBody();
+        $clientId = is_array($body) ? ($body['client_id'] ?? null) : null;
+        if (!is_string($clientId) || $clientId === '') {
+            throw new InvalidClientException('No client identification provided');
+        }
+
+        $client = $this->clientRepository->findById($clientId);
+        if ($client === null) {
+            throw new InvalidClientException('Unknown client');
+        }
+
+        if (!$client->isPublic()) {
+            throw new InvalidClientException('Confidential client must authenticate');
+        }
+
+        return $client;
+    }
+}

--- a/src/Server/ClientAuthentication/ClientSecretBasic.php
+++ b/src/Server/ClientAuthentication/ClientSecretBasic.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\ClientAuthentication;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ClientSecretBasic implements ClientAuthenticator
+{
+    public function getMethod(): string
+    {
+        return 'client_secret_basic';
+    }
+
+    public function authenticate(ServerRequestInterface $request): ?array
+    {
+        $header = $request->getHeaderLine('Authorization');
+        if ($header === '' || !str_starts_with($header, 'Basic ')) {
+            return null;
+        }
+
+        $decoded = base64_decode(substr($header, 6), true);
+        if ($decoded === false || !str_contains($decoded, ':')) {
+            return null;
+        }
+
+        [$clientId, $clientSecret] = explode(':', $decoded, 2);
+
+        return [urldecode($clientId), urldecode($clientSecret)];
+    }
+}

--- a/src/Server/ClientAuthentication/ClientSecretPost.php
+++ b/src/Server/ClientAuthentication/ClientSecretPost.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\ClientAuthentication;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ClientSecretPost implements ClientAuthenticator
+{
+    public function getMethod(): string
+    {
+        return 'client_secret_post';
+    }
+
+    public function authenticate(ServerRequestInterface $request): ?array
+    {
+        $body = $request->getParsedBody();
+        if (!is_array($body)) {
+            return null;
+        }
+
+        $clientId = $body['client_id'] ?? null;
+        $clientSecret = $body['client_secret'] ?? null;
+
+        if (!is_string($clientId) || $clientId === '') {
+            return null;
+        }
+
+        return [$clientId, is_string($clientSecret) ? $clientSecret : null];
+    }
+}

--- a/src/Server/Entity/AccessToken.php
+++ b/src/Server/Entity/AccessToken.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Entity;
+
+final class AccessToken
+{
+    public function __construct(
+        public readonly string $tokenId,
+        public readonly string $clientId,
+        public readonly ?string $identityId,
+        public readonly string $scope,
+        public readonly \DateTimeImmutable $expiresAt,
+        public readonly bool $revoked = false,
+    ) {}
+
+    public function isExpired(): bool
+    {
+        return new \DateTimeImmutable() >= $this->expiresAt;
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revoked;
+    }
+
+    /**
+     * @return Scope[]
+     */
+    public function getScopes(): array
+    {
+        return Scope::fromSpaceSeparated($this->scope);
+    }
+}

--- a/src/Server/Entity/AccessToken.php
+++ b/src/Server/Entity/AccessToken.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Server\Entity;
 
+use DateTimeImmutable;
+
 final class AccessToken
 {
     public function __construct(
@@ -20,13 +22,13 @@ final class AccessToken
         public readonly string $clientId,
         public readonly ?string $identityId,
         public readonly string $scope,
-        public readonly \DateTimeImmutable $expiresAt,
+        public readonly DateTimeImmutable $expiresAt,
         public readonly bool $revoked = false,
     ) {}
 
     public function isExpired(): bool
     {
-        return new \DateTimeImmutable() >= $this->expiresAt;
+        return new DateTimeImmutable() >= $this->expiresAt;
     }
 
     public function isRevoked(): bool

--- a/src/Server/Entity/AuthorizationCode.php
+++ b/src/Server/Entity/AuthorizationCode.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Server\Entity;
 
+use DateTimeImmutable;
+
 final class AuthorizationCode
 {
     public function __construct(
@@ -24,13 +26,13 @@ final class AuthorizationCode
         public readonly ?string $codeChallenge,
         public readonly ?string $codeChallengeMethod,
         public readonly ?string $nonce,
-        public readonly \DateTimeImmutable $expiresAt,
+        public readonly DateTimeImmutable $expiresAt,
         public readonly bool $used = false,
     ) {}
 
     public function isExpired(): bool
     {
-        return new \DateTimeImmutable() >= $this->expiresAt;
+        return new DateTimeImmutable() >= $this->expiresAt;
     }
 
     public function isUsed(): bool

--- a/src/Server/Entity/AuthorizationCode.php
+++ b/src/Server/Entity/AuthorizationCode.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Entity;
+
+final class AuthorizationCode
+{
+    public function __construct(
+        public readonly string $code,
+        public readonly string $clientId,
+        public readonly string $identityId,
+        public readonly string $redirectUri,
+        public readonly string $scope,
+        public readonly ?string $codeChallenge,
+        public readonly ?string $codeChallengeMethod,
+        public readonly ?string $nonce,
+        public readonly \DateTimeImmutable $expiresAt,
+        public readonly bool $used = false,
+    ) {}
+
+    public function isExpired(): bool
+    {
+        return new \DateTimeImmutable() >= $this->expiresAt;
+    }
+
+    public function isUsed(): bool
+    {
+        return $this->used;
+    }
+}

--- a/src/Server/Entity/Client.php
+++ b/src/Server/Entity/Client.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Entity;
+
+final class Client
+{
+    /**
+     * @param string[] $redirectUris
+     * @param string[] $grantTypes
+     */
+    public function __construct(
+        public readonly string $clientId,
+        public readonly ?string $clientSecretHash,
+        public readonly string $clientName,
+        public readonly array $redirectUris,
+        public readonly array $grantTypes,
+        public readonly string $scope,
+        public readonly string $clientType,
+        public readonly string $tokenEndpointAuthMethod = 'client_secret_basic',
+        public readonly ?\DateTimeImmutable $createdAt = null,
+        public readonly ?\DateTimeImmutable $updatedAt = null,
+    ) {}
+
+    public function isConfidential(): bool
+    {
+        return $this->clientType === 'confidential';
+    }
+
+    public function isPublic(): bool
+    {
+        return $this->clientType === 'public';
+    }
+
+    public function supportsGrantType(string $grantType): bool
+    {
+        return in_array($grantType, $this->grantTypes, true);
+    }
+
+    public function hasRedirectUri(string $uri): bool
+    {
+        return in_array($uri, $this->redirectUris, true);
+    }
+
+    public function verifySecret(string $plainSecret): bool
+    {
+        if ($this->clientSecretHash === null) {
+            return false;
+        }
+
+        return password_verify($plainSecret, $this->clientSecretHash);
+    }
+
+    /**
+     * @return Scope[]
+     */
+    public function getDefaultScopes(): array
+    {
+        return Scope::fromSpaceSeparated($this->scope);
+    }
+}

--- a/src/Server/Entity/Client.php
+++ b/src/Server/Entity/Client.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Server\Entity;
 
+use DateTimeImmutable;
+
 final class Client
 {
     /**
@@ -28,8 +30,8 @@ final class Client
         public readonly string $scope,
         public readonly string $clientType,
         public readonly string $tokenEndpointAuthMethod = 'client_secret_basic',
-        public readonly ?\DateTimeImmutable $createdAt = null,
-        public readonly ?\DateTimeImmutable $updatedAt = null,
+        public readonly ?DateTimeImmutable $createdAt = null,
+        public readonly ?DateTimeImmutable $updatedAt = null,
     ) {}
 
     public function isConfidential(): bool

--- a/src/Server/Entity/Consent.php
+++ b/src/Server/Entity/Consent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Entity;
+
+final class Consent
+{
+    public function __construct(
+        public readonly string $identityId,
+        public readonly string $clientId,
+        public readonly string $scope,
+        public readonly \DateTimeImmutable $grantedAt,
+    ) {}
+
+    public function coversScope(string $requestedScope): bool
+    {
+        $granted = array_filter(explode(' ', $this->scope));
+        $requested = array_filter(explode(' ', $requestedScope));
+
+        return array_diff($requested, $granted) === [];
+    }
+}

--- a/src/Server/Entity/Consent.php
+++ b/src/Server/Entity/Consent.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Server\Entity;
 
+use DateTimeImmutable;
+
 final class Consent
 {
     public function __construct(
         public readonly string $identityId,
         public readonly string $clientId,
         public readonly string $scope,
-        public readonly \DateTimeImmutable $grantedAt,
+        public readonly DateTimeImmutable $grantedAt,
     ) {}
 
     public function coversScope(string $requestedScope): bool

--- a/src/Server/Entity/RefreshToken.php
+++ b/src/Server/Entity/RefreshToken.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Entity;
+
+final class RefreshToken
+{
+    public function __construct(
+        public readonly string $tokenId,
+        public readonly string $accessTokenId,
+        public readonly string $clientId,
+        public readonly ?string $identityId,
+        public readonly string $scope,
+        public readonly \DateTimeImmutable $expiresAt,
+        public readonly bool $revoked = false,
+    ) {}
+
+    public function isExpired(): bool
+    {
+        return new \DateTimeImmutable() >= $this->expiresAt;
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revoked;
+    }
+}

--- a/src/Server/Entity/RefreshToken.php
+++ b/src/Server/Entity/RefreshToken.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Horde\Oauth\Server\Entity;
 
+use DateTimeImmutable;
+
 final class RefreshToken
 {
     public function __construct(
@@ -21,13 +23,13 @@ final class RefreshToken
         public readonly string $clientId,
         public readonly ?string $identityId,
         public readonly string $scope,
-        public readonly \DateTimeImmutable $expiresAt,
+        public readonly DateTimeImmutable $expiresAt,
         public readonly bool $revoked = false,
     ) {}
 
     public function isExpired(): bool
     {
-        return new \DateTimeImmutable() >= $this->expiresAt;
+        return new DateTimeImmutable() >= $this->expiresAt;
     }
 
     public function isRevoked(): bool

--- a/src/Server/Entity/Scope.php
+++ b/src/Server/Entity/Scope.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Entity;
+
+final class Scope
+{
+    public function __construct(
+        public readonly string $identifier,
+    ) {}
+
+    public function __toString(): string
+    {
+        return $this->identifier;
+    }
+
+    public static function fromString(string $scope): self
+    {
+        return new self(trim($scope));
+    }
+
+    /**
+     * @return self[]
+     */
+    public static function fromSpaceSeparated(string $scopes): array
+    {
+        if (trim($scopes) === '') {
+            return [];
+        }
+
+        return array_map(
+            static fn(string $s) => new self(trim($s)),
+            explode(' ', $scopes),
+        );
+    }
+
+    /**
+     * @param self[] $scopes
+     */
+    public static function toSpaceSeparated(array $scopes): string
+    {
+        return implode(' ', array_map(
+            static fn(self $s) => $s->identifier,
+            $scopes,
+        ));
+    }
+}

--- a/src/Server/Grant/AuthorizationCodeGrant.php
+++ b/src/Server/Grant/AuthorizationCodeGrant.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Grant;
+
+use Horde\Oauth\Exception\InvalidGrantException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Pkce\PkceVerifier;
+use Horde\Oauth\Server\Repository\AuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\ScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Server\Token\RefreshTokenIssuer;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class AuthorizationCodeGrant implements Grant
+{
+    public function __construct(
+        private readonly AuthorizationCodeRepository $authCodeRepository,
+        private readonly AccessTokenIssuer $accessTokenIssuer,
+        private readonly ?RefreshTokenIssuer $refreshTokenIssuer,
+        private readonly ScopeRepository $scopeRepository,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return 'authorization_code';
+    }
+
+    public function respondToTokenRequest(ServerRequestInterface $request, Client $client): array
+    {
+        $body = (array) $request->getParsedBody();
+
+        $code = $body['code'] ?? null;
+        if (!is_string($code) || $code === '') {
+            throw new InvalidRequestException('Missing required parameter: code');
+        }
+
+        $redirectUri = $body['redirect_uri'] ?? null;
+
+        $authCode = $this->authCodeRepository->findByCode($code);
+        if ($authCode === null) {
+            throw new InvalidGrantException('Authorization code is invalid');
+        }
+
+        if ($authCode->isUsed()) {
+            throw new InvalidGrantException('Authorization code has already been used');
+        }
+
+        if ($authCode->isExpired()) {
+            throw new InvalidGrantException('Authorization code has expired');
+        }
+
+        if ($authCode->clientId !== $client->clientId) {
+            throw new InvalidGrantException('Authorization code was not issued to this client');
+        }
+
+        if ($authCode->redirectUri !== '' && $authCode->redirectUri !== $redirectUri) {
+            throw new InvalidGrantException('Redirect URI mismatch');
+        }
+
+        if ($authCode->codeChallenge !== null) {
+            $codeVerifier = $body['code_verifier'] ?? null;
+            if (!is_string($codeVerifier) || $codeVerifier === '') {
+                throw new InvalidRequestException('Missing required parameter: code_verifier');
+            }
+            $method = $authCode->codeChallengeMethod ?? 'plain';
+            if (!PkceVerifier::verify($codeVerifier, $authCode->codeChallenge, $method)) {
+                throw new InvalidGrantException('PKCE verification failed');
+            }
+        }
+
+        $this->authCodeRepository->markUsed($code);
+
+        $scopes = Scope::fromSpaceSeparated($authCode->scope);
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client, $authCode->identityId);
+
+        $response = $this->accessTokenIssuer->issue($client, $authCode->identityId, $scopes);
+
+        if ($this->refreshTokenIssuer !== null) {
+            $jti = $response['_jti'];
+            $response['refresh_token'] = $this->refreshTokenIssuer->issue($jti, $client, $authCode->identityId, $scopes);
+        }
+
+        unset($response['_jti']);
+
+        $response['_identity_id'] = $authCode->identityId;
+        $response['_nonce'] = $authCode->nonce;
+
+        return $response;
+    }
+}

--- a/src/Server/Grant/ClientCredentialsGrant.php
+++ b/src/Server/Grant/ClientCredentialsGrant.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Grant;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\ScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ClientCredentialsGrant implements Grant
+{
+    public function __construct(
+        private readonly AccessTokenIssuer $accessTokenIssuer,
+        private readonly ScopeRepository $scopeRepository,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return 'client_credentials';
+    }
+
+    public function respondToTokenRequest(ServerRequestInterface $request, Client $client): array
+    {
+        $body = (array) $request->getParsedBody();
+
+        $requestedScope = $body['scope'] ?? '';
+        $scopes = is_string($requestedScope) ? Scope::fromSpaceSeparated($requestedScope) : [];
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client);
+
+        $response = $this->accessTokenIssuer->issue($client, null, $scopes);
+
+        unset($response['_jti']);
+
+        return $response;
+    }
+}

--- a/src/Server/Grant/Grant.php
+++ b/src/Server/Grant/Grant.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Grant;
+
+use Horde\Oauth\Exception\OAuthException;
+use Horde\Oauth\Server\Entity\Client;
+use Psr\Http\Message\ServerRequestInterface;
+
+interface Grant
+{
+    public function getIdentifier(): string;
+
+    /**
+     * @return array<string, mixed>
+     * @throws OAuthException
+     */
+    public function respondToTokenRequest(ServerRequestInterface $request, Client $client): array;
+}

--- a/src/Server/Grant/RefreshTokenGrant.php
+++ b/src/Server/Grant/RefreshTokenGrant.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Grant;
+
+use Horde\Oauth\Exception\InvalidGrantException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+use Horde\Oauth\Server\Repository\ScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Server\Token\RefreshTokenIssuer;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RefreshTokenGrant implements Grant
+{
+    public function __construct(
+        private readonly RefreshTokenRepository $refreshTokenRepository,
+        private readonly AccessTokenRepository $accessTokenRepository,
+        private readonly AccessTokenIssuer $accessTokenIssuer,
+        private readonly ?RefreshTokenIssuer $refreshTokenIssuer,
+        private readonly ScopeRepository $scopeRepository,
+    ) {}
+
+    public function getIdentifier(): string
+    {
+        return 'refresh_token';
+    }
+
+    public function respondToTokenRequest(ServerRequestInterface $request, Client $client): array
+    {
+        $body = (array) $request->getParsedBody();
+
+        $refreshTokenId = $body['refresh_token'] ?? null;
+        if (!is_string($refreshTokenId) || $refreshTokenId === '') {
+            throw new InvalidRequestException('Missing required parameter: refresh_token');
+        }
+
+        $refreshToken = $this->refreshTokenRepository->findById($refreshTokenId);
+        if ($refreshToken === null) {
+            throw new InvalidGrantException('Refresh token is invalid');
+        }
+
+        if ($refreshToken->isRevoked()) {
+            throw new InvalidGrantException('Refresh token has been revoked');
+        }
+
+        if ($refreshToken->isExpired()) {
+            throw new InvalidGrantException('Refresh token has expired');
+        }
+
+        if ($refreshToken->clientId !== $client->clientId) {
+            throw new InvalidGrantException('Refresh token was not issued to this client');
+        }
+
+        $requestedScope = $body['scope'] ?? '';
+        $scopes = is_string($requestedScope) && $requestedScope !== ''
+            ? Scope::fromSpaceSeparated($requestedScope)
+            : Scope::fromSpaceSeparated($refreshToken->scope);
+
+        if ($requestedScope !== '') {
+            $originalScopes = array_map(
+                static fn(Scope $s) => $s->identifier,
+                Scope::fromSpaceSeparated($refreshToken->scope),
+            );
+            foreach ($scopes as $scope) {
+                if (!in_array($scope->identifier, $originalScopes, true)) {
+                    throw new InvalidGrantException('Requested scope exceeds original grant');
+                }
+            }
+        }
+
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client, $refreshToken->identityId);
+
+        $this->accessTokenRepository->revoke($refreshToken->accessTokenId);
+        $this->refreshTokenRepository->revoke($refreshTokenId);
+
+        $response = $this->accessTokenIssuer->issue($client, $refreshToken->identityId, $scopes);
+
+        if ($this->refreshTokenIssuer !== null) {
+            $jti = $response['_jti'];
+            $response['refresh_token'] = $this->refreshTokenIssuer->issue($jti, $client, $refreshToken->identityId, $scopes);
+        }
+
+        unset($response['_jti']);
+
+        return $response;
+    }
+}

--- a/src/Server/Handler/AuthorizationEndpoint.php
+++ b/src/Server/Handler/AuthorizationEndpoint.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Handler;
+
+use Horde\Oauth\ErrorResponse;
+use Horde\Oauth\Exception\AccessDeniedException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Exception\OAuthException;
+use Horde\Oauth\Server\AuthorizationRequest;
+use Horde\Oauth\Server\AuthorizationResult;
+use Horde\Oauth\Server\Entity\AuthorizationCode;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\AuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\ClientRepository;
+use Horde\Oauth\Server\Repository\ScopeRepository;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AuthorizationEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly ClientRepository $clientRepository,
+        private readonly ScopeRepository $scopeRepository,
+        private readonly AuthorizationCodeRepository $authCodeRepository,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function validateAuthorizationRequest(ServerRequestInterface $request): AuthorizationRequest
+    {
+        $params = $request->getQueryParams();
+
+        $responseType = $params['response_type'] ?? null;
+        if ($responseType !== 'code') {
+            throw new InvalidRequestException('Only response_type=code is supported');
+        }
+
+        $clientId = $params['client_id'] ?? null;
+        if (!is_string($clientId) || $clientId === '') {
+            throw new InvalidRequestException('Missing required parameter: client_id');
+        }
+
+        $client = $this->clientRepository->findById($clientId);
+        if ($client === null) {
+            throw new InvalidRequestException('Unknown client_id');
+        }
+
+        $redirectUri = $params['redirect_uri'] ?? '';
+        if ($redirectUri !== '' && !$client->hasRedirectUri($redirectUri)) {
+            throw new InvalidRequestException('Invalid redirect_uri');
+        }
+        if ($redirectUri === '' && count($client->redirectUris) === 1) {
+            $redirectUri = $client->redirectUris[0];
+        }
+        if ($redirectUri === '') {
+            throw new InvalidRequestException('Missing required parameter: redirect_uri');
+        }
+
+        $state = $params['state'] ?? '';
+        $scopeString = $params['scope'] ?? '';
+        $scopes = is_string($scopeString) ? Scope::fromSpaceSeparated($scopeString) : [];
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, 'authorization_code', $client);
+
+        $codeChallenge = $params['code_challenge'] ?? null;
+        $codeChallengeMethod = $params['code_challenge_method'] ?? ($codeChallenge !== null ? 'plain' : null);
+
+        $nonce = $params['nonce'] ?? null;
+
+        return new AuthorizationRequest(
+            $client,
+            $responseType,
+            $redirectUri,
+            is_string($state) ? $state : '',
+            $scopes,
+            is_string($codeChallenge) ? $codeChallenge : null,
+            is_string($codeChallengeMethod) ? $codeChallengeMethod : null,
+            is_string($nonce) ? $nonce : null,
+        );
+    }
+
+    public function completeAuthorizationRequest(AuthorizationResult $result): ResponseInterface
+    {
+        $request = $result->request;
+
+        if (!$result->approved) {
+            $query = http_build_query(array_filter([
+                'error' => 'access_denied',
+                'error_description' => 'The user denied the authorization request',
+                'state' => $request->state,
+            ]));
+            return $this->responseFactory->createResponse(302)
+                ->withHeader('Location', $request->redirectUri . '?' . $query);
+        }
+
+        $scopes = $result->approvedScopes ?? $request->scopes;
+        $code = bin2hex(random_bytes(32));
+
+        $authCode = new AuthorizationCode(
+            $code,
+            $request->client->clientId,
+            $result->identityId ?? '',
+            $request->redirectUri,
+            Scope::toSpaceSeparated($scopes),
+            $request->codeChallenge,
+            $request->codeChallengeMethod,
+            $request->nonce,
+            new \DateTimeImmutable('+10 minutes'),
+        );
+        $this->authCodeRepository->persist($authCode);
+
+        $query = http_build_query(array_filter([
+            'code' => $code,
+            'state' => $request->state,
+        ]));
+
+        return $this->responseFactory->createResponse(302)
+            ->withHeader('Location', $request->redirectUri . '?' . $query);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            $authRequest = $this->validateAuthorizationRequest($request);
+            return $this->responseFactory->createResponse(200)
+                ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+                ->withBody($this->streamFactory->createStream(json_encode([
+                    'client_id' => $authRequest->client->clientId,
+                    'client_name' => $authRequest->client->clientName,
+                    'scopes' => array_map(fn(Scope $s) => $s->identifier, $authRequest->scopes),
+                    'state' => $authRequest->state,
+                ], JSON_THROW_ON_ERROR)));
+        } catch (OAuthException $e) {
+            return ErrorResponse::toResponse($e, $this->responseFactory, $this->streamFactory);
+        }
+    }
+}

--- a/src/Server/Handler/AuthorizationEndpoint.php
+++ b/src/Server/Handler/AuthorizationEndpoint.php
@@ -29,6 +29,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use DateTimeImmutable;
 
 final class AuthorizationEndpoint implements RequestHandlerInterface
 {
@@ -118,7 +119,7 @@ final class AuthorizationEndpoint implements RequestHandlerInterface
             $request->codeChallenge,
             $request->codeChallengeMethod,
             $request->nonce,
-            new \DateTimeImmutable('+10 minutes'),
+            new DateTimeImmutable('+10 minutes'),
         );
         $this->authCodeRepository->persist($authCode);
 

--- a/src/Server/Handler/IntrospectionEndpoint.php
+++ b/src/Server/Handler/IntrospectionEndpoint.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Handler;
+
+use Horde\Oauth\ErrorResponse;
+use Horde\Oauth\Exception\OAuthException;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class IntrospectionEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly ClientAuthenticatorChain $clientAuthenticator,
+        private readonly AccessTokenRepository $accessTokenRepository,
+        private readonly RefreshTokenRepository $refreshTokenRepository,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            $this->clientAuthenticator->authenticateClient($request);
+        } catch (OAuthException $e) {
+            return ErrorResponse::toResponse($e, $this->responseFactory, $this->streamFactory);
+        }
+
+        $body = (array) $request->getParsedBody();
+        $tokenValue = $body['token'] ?? null;
+
+        if (!is_string($tokenValue) || $tokenValue === '') {
+            return $this->jsonResponse(['active' => false]);
+        }
+
+        $hint = $body['token_type_hint'] ?? null;
+
+        if ($hint === 'refresh_token') {
+            $refreshToken = $this->refreshTokenRepository->findById($tokenValue);
+            if ($refreshToken !== null && !$refreshToken->isRevoked() && !$refreshToken->isExpired()) {
+                return $this->jsonResponse([
+                    'active' => true,
+                    'scope' => $refreshToken->scope,
+                    'client_id' => $refreshToken->clientId,
+                    'sub' => $refreshToken->identityId,
+                    'exp' => $refreshToken->expiresAt->getTimestamp(),
+                    'token_type' => 'refresh_token',
+                ]);
+            }
+        }
+
+        $accessToken = $this->accessTokenRepository->findById($tokenValue);
+        if ($accessToken !== null && !$accessToken->isRevoked() && !$accessToken->isExpired()) {
+            return $this->jsonResponse([
+                'active' => true,
+                'scope' => $accessToken->scope,
+                'client_id' => $accessToken->clientId,
+                'sub' => $accessToken->identityId,
+                'exp' => $accessToken->expiresAt->getTimestamp(),
+                'token_type' => 'Bearer',
+            ]);
+        }
+
+        return $this->jsonResponse(['active' => false]);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function jsonResponse(array $data): ResponseInterface
+    {
+        $json = json_encode($data, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        $body = $this->streamFactory->createStream($json);
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withHeader('Cache-Control', 'no-store')
+            ->withBody($body);
+    }
+}

--- a/src/Server/Handler/MetadataEndpoint.php
+++ b/src/Server/Handler/MetadataEndpoint.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Handler;
+
+use Horde\Oauth\Server\ServerMetadata;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class MetadataEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly ServerMetadata $metadata,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = $this->streamFactory->createStream($this->metadata->toJson());
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withBody($body);
+    }
+}

--- a/src/Server/Handler/RevocationEndpoint.php
+++ b/src/Server/Handler/RevocationEndpoint.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Handler;
+
+use Horde\Oauth\ErrorResponse;
+use Horde\Oauth\Exception\OAuthException;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class RevocationEndpoint implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly ClientAuthenticatorChain $clientAuthenticator,
+        private readonly AccessTokenRepository $accessTokenRepository,
+        private readonly RefreshTokenRepository $refreshTokenRepository,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            $this->clientAuthenticator->authenticateClient($request);
+        } catch (OAuthException $e) {
+            return ErrorResponse::toResponse($e, $this->responseFactory, $this->streamFactory);
+        }
+
+        $body = (array) $request->getParsedBody();
+        $token = $body['token'] ?? null;
+
+        if (!is_string($token) || $token === '') {
+            return $this->responseFactory->createResponse(200);
+        }
+
+        $hint = $body['token_type_hint'] ?? null;
+
+        if ($hint === 'refresh_token') {
+            $this->refreshTokenRepository->revoke($token);
+        } elseif ($hint === 'access_token') {
+            $this->accessTokenRepository->revoke($token);
+        } else {
+            $this->accessTokenRepository->revoke($token);
+            $this->refreshTokenRepository->revoke($token);
+        }
+
+        return $this->responseFactory->createResponse(200);
+    }
+}

--- a/src/Server/Handler/TokenEndpoint.php
+++ b/src/Server/Handler/TokenEndpoint.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Handler;
+
+use Horde\Oauth\ErrorResponse;
+use Horde\Oauth\Exception\OAuthException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Exception\UnsupportedGrantTypeException;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\Grant\Grant;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class TokenEndpoint implements RequestHandlerInterface
+{
+    /** @var array<string, Grant> */
+    private array $grants = [];
+
+    public function __construct(
+        private readonly ClientAuthenticatorChain $clientAuthenticator,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        Grant ...$grants,
+    ) {
+        foreach ($grants as $grant) {
+            $this->grants[$grant->getIdentifier()] = $grant;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        try {
+            $body = (array) $request->getParsedBody();
+
+            $grantType = $body['grant_type'] ?? null;
+            if (!is_string($grantType) || $grantType === '') {
+                throw new InvalidRequestException('Missing required parameter: grant_type');
+            }
+
+            $grant = $this->grants[$grantType] ?? null;
+            if ($grant === null) {
+                throw new UnsupportedGrantTypeException("Grant type '{$grantType}' is not supported");
+            }
+
+            $client = $this->clientAuthenticator->authenticateClientOrPublic($request);
+
+            if (!$client->supportsGrantType($grantType)) {
+                throw new UnsupportedGrantTypeException("Client is not authorized for grant type '{$grantType}'");
+            }
+
+            $result = $grant->respondToTokenRequest($request, $client);
+
+            $filtered = array_filter($result, static fn(string $key) => !str_starts_with($key, '_'), ARRAY_FILTER_USE_KEY);
+
+            $json = json_encode($filtered, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+            $responseBody = $this->streamFactory->createStream($json);
+
+            return $this->responseFactory->createResponse(200)
+                ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+                ->withHeader('Cache-Control', 'no-store')
+                ->withHeader('Pragma', 'no-cache')
+                ->withBody($responseBody);
+        } catch (OAuthException $e) {
+            return ErrorResponse::toResponse($e, $this->responseFactory, $this->streamFactory);
+        }
+    }
+}

--- a/src/Server/Middleware/BearerTokenMiddleware.php
+++ b/src/Server/Middleware/BearerTokenMiddleware.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Middleware;
+
+use Horde\Jwt\Exception\ExpiredTokenException;
+use Horde\Jwt\Exception\InvalidTokenException;
+use Horde\Jwt\TokenDecoder;
+use Horde\Jwt\Verifier\VerifierInterface;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class BearerTokenMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param array<string, mixed> $verifyOptions
+     */
+    public function __construct(
+        private readonly TokenDecoder $decoder,
+        private readonly VerifierInterface $verifier,
+        private readonly AccessTokenRepository $tokenRepository,
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+        private readonly bool $required = true,
+        private readonly array $verifyOptions = [],
+    ) {}
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $header = $request->getHeaderLine('Authorization');
+        $token = null;
+
+        if (str_starts_with($header, 'Bearer ')) {
+            $token = substr($header, 7);
+        }
+
+        if ($token === null || $token === '') {
+            if ($this->required) {
+                return $this->unauthorized('No access token provided');
+            }
+            return $handler->handle($request);
+        }
+
+        try {
+            $verified = $this->decoder->decode($token, $this->verifier, $this->verifyOptions);
+        } catch (ExpiredTokenException) {
+            return $this->unauthorized('Access token has expired', 'invalid_token');
+        } catch (InvalidTokenException) {
+            return $this->unauthorized('Access token is invalid', 'invalid_token');
+        }
+
+        $jti = $verified->getClaim('jti');
+        if (is_string($jti) && $this->tokenRepository->isRevoked($jti)) {
+            return $this->unauthorized('Access token has been revoked', 'invalid_token');
+        }
+
+        $request = $request
+            ->withAttribute('oauth_access_token', $verified)
+            ->withAttribute('oauth_client_id', $verified->getClaim('client_id'))
+            ->withAttribute('oauth_user_id', $verified->getSubject())
+            ->withAttribute('oauth_scopes', $verified->getClaim('scope', ''));
+
+        return $handler->handle($request);
+    }
+
+    private function unauthorized(string $description, string $error = ''): ResponseInterface
+    {
+        $wwwAuth = 'Bearer';
+        if ($error !== '') {
+            $wwwAuth .= " error=\"{$error}\", error_description=\"{$description}\"";
+        }
+
+        $body = json_encode(array_filter([
+            'error' => $error ?: 'invalid_request',
+            'error_description' => $description,
+        ]), JSON_THROW_ON_ERROR);
+
+        return $this->responseFactory->createResponse(401)
+            ->withHeader('WWW-Authenticate', $wwwAuth)
+            ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+            ->withBody($this->streamFactory->createStream($body));
+    }
+}

--- a/src/Server/Pkce/PkceVerifier.php
+++ b/src/Server/Pkce/PkceVerifier.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Pkce;
+
+use Horde\Jwt\Base64Url;
+use Horde\Oauth\Exception\InvalidRequestException;
+
+final class PkceVerifier
+{
+    public static function verify(string $codeVerifier, string $codeChallenge, string $method): bool
+    {
+        if (!self::isValidMethod($method)) {
+            throw new InvalidRequestException("Unsupported code_challenge_method: {$method}");
+        }
+
+        if ($method === 'S256') {
+            $computed = Base64Url::encode(hash('sha256', $codeVerifier, true));
+            return hash_equals($codeChallenge, $computed);
+        }
+
+        return hash_equals($codeChallenge, $codeVerifier);
+    }
+
+    public static function isValidMethod(string $method): bool
+    {
+        return in_array($method, ['S256', 'plain'], true);
+    }
+}

--- a/src/Server/Repository/AccessTokenRepository.php
+++ b/src/Server/Repository/AccessTokenRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository;
+
+use Horde\Oauth\Server\Entity\AccessToken;
+
+interface AccessTokenRepository
+{
+    public function persist(AccessToken $token): void;
+
+    public function findById(string $tokenId): ?AccessToken;
+
+    public function revoke(string $tokenId): void;
+
+    public function isRevoked(string $tokenId): bool;
+}

--- a/src/Server/Repository/AuthorizationCodeRepository.php
+++ b/src/Server/Repository/AuthorizationCodeRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository;
+
+use Horde\Oauth\Server\Entity\AuthorizationCode;
+
+interface AuthorizationCodeRepository
+{
+    public function persist(AuthorizationCode $code): void;
+
+    public function findByCode(string $code): ?AuthorizationCode;
+
+    public function markUsed(string $code): void;
+
+    public function isUsed(string $code): bool;
+}

--- a/src/Server/Repository/ClientRepository.php
+++ b/src/Server/Repository/ClientRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository;
+
+use Horde\Oauth\Server\Entity\Client;
+
+interface ClientRepository
+{
+    public function findById(string $clientId): ?Client;
+
+    public function validateClient(string $clientId, ?string $clientSecret, string $grantType): bool;
+}

--- a/src/Server/Repository/ConsentRepository.php
+++ b/src/Server/Repository/ConsentRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository;
+
+use Horde\Oauth\Server\Entity\Consent;
+
+interface ConsentRepository
+{
+    public function findConsent(string $identityId, string $clientId): ?Consent;
+
+    public function persist(Consent $consent): void;
+
+    public function revoke(string $identityId, string $clientId): void;
+}

--- a/src/Server/Repository/InMemory/InMemoryAccessTokenRepository.php
+++ b/src/Server/Repository/InMemory/InMemoryAccessTokenRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\AccessToken;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+
+final class InMemoryAccessTokenRepository implements AccessTokenRepository
+{
+    /** @var array<string, AccessToken> */
+    private array $tokens = [];
+
+    public function persist(AccessToken $token): void
+    {
+        $this->tokens[$token->tokenId] = $token;
+    }
+
+    public function findById(string $tokenId): ?AccessToken
+    {
+        return $this->tokens[$tokenId] ?? null;
+    }
+
+    public function revoke(string $tokenId): void
+    {
+        $token = $this->tokens[$tokenId] ?? null;
+        if ($token !== null) {
+            $this->tokens[$tokenId] = new AccessToken(
+                $token->tokenId,
+                $token->clientId,
+                $token->identityId,
+                $token->scope,
+                $token->expiresAt,
+                revoked: true,
+            );
+        }
+    }
+
+    public function isRevoked(string $tokenId): bool
+    {
+        $token = $this->tokens[$tokenId] ?? null;
+        return $token !== null && $token->revoked;
+    }
+}

--- a/src/Server/Repository/InMemory/InMemoryAuthorizationCodeRepository.php
+++ b/src/Server/Repository/InMemory/InMemoryAuthorizationCodeRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\AuthorizationCode;
+use Horde\Oauth\Server\Repository\AuthorizationCodeRepository;
+
+final class InMemoryAuthorizationCodeRepository implements AuthorizationCodeRepository
+{
+    /** @var array<string, AuthorizationCode> */
+    private array $codes = [];
+
+    public function persist(AuthorizationCode $code): void
+    {
+        $this->codes[$code->code] = $code;
+    }
+
+    public function findByCode(string $code): ?AuthorizationCode
+    {
+        return $this->codes[$code] ?? null;
+    }
+
+    public function markUsed(string $code): void
+    {
+        $existing = $this->codes[$code] ?? null;
+        if ($existing !== null) {
+            $this->codes[$code] = new AuthorizationCode(
+                $existing->code,
+                $existing->clientId,
+                $existing->identityId,
+                $existing->redirectUri,
+                $existing->scope,
+                $existing->codeChallenge,
+                $existing->codeChallengeMethod,
+                $existing->nonce,
+                $existing->expiresAt,
+                used: true,
+            );
+        }
+    }
+
+    public function isUsed(string $code): bool
+    {
+        $existing = $this->codes[$code] ?? null;
+        return $existing !== null && $existing->used;
+    }
+}

--- a/src/Server/Repository/InMemory/InMemoryClientRepository.php
+++ b/src/Server/Repository/InMemory/InMemoryClientRepository.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Repository\ClientRepository;
+
+final class InMemoryClientRepository implements ClientRepository
+{
+    /** @var array<string, Client> */
+    private array $clients = [];
+
+    public function __construct(Client ...$clients)
+    {
+        foreach ($clients as $client) {
+            $this->clients[$client->clientId] = $client;
+        }
+    }
+
+    public function findById(string $clientId): ?Client
+    {
+        return $this->clients[$clientId] ?? null;
+    }
+
+    public function validateClient(string $clientId, ?string $clientSecret, string $grantType): bool
+    {
+        $client = $this->findById($clientId);
+        if ($client === null) {
+            return false;
+        }
+
+        if (!$client->supportsGrantType($grantType)) {
+            return false;
+        }
+
+        if ($client->isConfidential()) {
+            if ($clientSecret === null) {
+                return false;
+            }
+            return $client->verifySecret($clientSecret);
+        }
+
+        return true;
+    }
+}

--- a/src/Server/Repository/InMemory/InMemoryConsentRepository.php
+++ b/src/Server/Repository/InMemory/InMemoryConsentRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\Consent;
+use Horde\Oauth\Server\Repository\ConsentRepository;
+
+final class InMemoryConsentRepository implements ConsentRepository
+{
+    /** @var array<string, Consent> */
+    private array $consents = [];
+
+    public function findConsent(string $identityId, string $clientId): ?Consent
+    {
+        return $this->consents[$this->key($identityId, $clientId)] ?? null;
+    }
+
+    public function persist(Consent $consent): void
+    {
+        $this->consents[$this->key($consent->identityId, $consent->clientId)] = $consent;
+    }
+
+    public function revoke(string $identityId, string $clientId): void
+    {
+        unset($this->consents[$this->key($identityId, $clientId)]);
+    }
+
+    private function key(string $identityId, string $clientId): string
+    {
+        return "{$identityId}:{$clientId}";
+    }
+}

--- a/src/Server/Repository/InMemory/InMemoryRefreshTokenRepository.php
+++ b/src/Server/Repository/InMemory/InMemoryRefreshTokenRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\RefreshToken;
+use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+
+final class InMemoryRefreshTokenRepository implements RefreshTokenRepository
+{
+    /** @var array<string, RefreshToken> */
+    private array $tokens = [];
+
+    public function persist(RefreshToken $token): void
+    {
+        $this->tokens[$token->tokenId] = $token;
+    }
+
+    public function findById(string $tokenId): ?RefreshToken
+    {
+        return $this->tokens[$tokenId] ?? null;
+    }
+
+    public function revoke(string $tokenId): void
+    {
+        $token = $this->tokens[$tokenId] ?? null;
+        if ($token !== null) {
+            $this->tokens[$tokenId] = new RefreshToken(
+                $token->tokenId,
+                $token->accessTokenId,
+                $token->clientId,
+                $token->identityId,
+                $token->scope,
+                $token->expiresAt,
+                revoked: true,
+            );
+        }
+    }
+
+    public function isRevoked(string $tokenId): bool
+    {
+        $token = $this->tokens[$tokenId] ?? null;
+        return $token !== null && $token->revoked;
+    }
+
+    public function revokeByAccessTokenId(string $accessTokenId): void
+    {
+        foreach ($this->tokens as $id => $token) {
+            if ($token->accessTokenId === $accessTokenId) {
+                $this->revoke($id);
+            }
+        }
+    }
+}

--- a/src/Server/Repository/InMemory/InMemoryScopeRepository.php
+++ b/src/Server/Repository/InMemory/InMemoryScopeRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\ScopeRepository;
+
+final class InMemoryScopeRepository implements ScopeRepository
+{
+    /** @var array<string, Scope> */
+    private array $scopes = [];
+
+    public function __construct(Scope ...$scopes)
+    {
+        foreach ($scopes as $scope) {
+            $this->scopes[$scope->identifier] = $scope;
+        }
+    }
+
+    public function findByIdentifier(string $identifier): ?Scope
+    {
+        return $this->scopes[$identifier] ?? null;
+    }
+
+    public function finalizeScopes(
+        array $scopes,
+        string $grantType,
+        Client $client,
+        ?string $identityId = null,
+    ): array {
+        if ($scopes === []) {
+            return $client->getDefaultScopes();
+        }
+
+        return array_values(array_filter(
+            $scopes,
+            fn(Scope $scope) => isset($this->scopes[$scope->identifier]),
+        ));
+    }
+}

--- a/src/Server/Repository/RefreshTokenRepository.php
+++ b/src/Server/Repository/RefreshTokenRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository;
+
+use Horde\Oauth\Server\Entity\RefreshToken;
+
+interface RefreshTokenRepository
+{
+    public function persist(RefreshToken $token): void;
+
+    public function findById(string $tokenId): ?RefreshToken;
+
+    public function revoke(string $tokenId): void;
+
+    public function isRevoked(string $tokenId): bool;
+
+    public function revokeByAccessTokenId(string $accessTokenId): void;
+}

--- a/src/Server/Repository/ScopeRepository.php
+++ b/src/Server/Repository/ScopeRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Repository;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+
+interface ScopeRepository
+{
+    public function findByIdentifier(string $identifier): ?Scope;
+
+    /**
+     * @param Scope[] $scopes
+     * @return Scope[]
+     */
+    public function finalizeScopes(
+        array $scopes,
+        string $grantType,
+        Client $client,
+        ?string $identityId = null,
+    ): array;
+}

--- a/src/Server/ServerMetadata.php
+++ b/src/Server/ServerMetadata.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server;
+
+final class ServerMetadata
+{
+    /**
+     * @param string[] $scopesSupported
+     * @param string[] $responseTypesSupported
+     * @param string[] $grantTypesSupported
+     * @param string[] $tokenEndpointAuthMethodsSupported
+     * @param string[] $codeChallengeMethodsSupported
+     * @param string[] $subjectTypesSupported
+     * @param string[] $idTokenSigningAlgValuesSupported
+     */
+    public function __construct(
+        public readonly string $issuer,
+        public readonly string $authorizationEndpoint,
+        public readonly string $tokenEndpoint,
+        public readonly ?string $revocationEndpoint = null,
+        public readonly ?string $introspectionEndpoint = null,
+        public readonly ?string $jwksUri = null,
+        public readonly ?string $userinfoEndpoint = null,
+        public readonly array $scopesSupported = [],
+        public readonly array $responseTypesSupported = ['code'],
+        public readonly array $grantTypesSupported = ['authorization_code', 'client_credentials', 'refresh_token'],
+        public readonly array $tokenEndpointAuthMethodsSupported = ['client_secret_basic', 'client_secret_post'],
+        public readonly array $codeChallengeMethodsSupported = ['S256'],
+        public readonly array $subjectTypesSupported = ['public'],
+        public readonly array $idTokenSigningAlgValuesSupported = ['RS256'],
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'issuer' => $this->issuer,
+            'authorization_endpoint' => $this->authorizationEndpoint,
+            'token_endpoint' => $this->tokenEndpoint,
+        ];
+
+        if ($this->revocationEndpoint !== null) {
+            $data['revocation_endpoint'] = $this->revocationEndpoint;
+        }
+        if ($this->introspectionEndpoint !== null) {
+            $data['introspection_endpoint'] = $this->introspectionEndpoint;
+        }
+        if ($this->jwksUri !== null) {
+            $data['jwks_uri'] = $this->jwksUri;
+        }
+        if ($this->userinfoEndpoint !== null) {
+            $data['userinfo_endpoint'] = $this->userinfoEndpoint;
+        }
+
+        $data['scopes_supported'] = $this->scopesSupported;
+        $data['response_types_supported'] = $this->responseTypesSupported;
+        $data['grant_types_supported'] = $this->grantTypesSupported;
+        $data['token_endpoint_auth_methods_supported'] = $this->tokenEndpointAuthMethodsSupported;
+        $data['code_challenge_methods_supported'] = $this->codeChallengeMethodsSupported;
+        $data['subject_types_supported'] = $this->subjectTypesSupported;
+        $data['id_token_signing_alg_values_supported'] = $this->idTokenSigningAlgValuesSupported;
+
+        return $data;
+    }
+
+    public function toJson(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Server/Token/AccessTokenIssuer.php
+++ b/src/Server/Token/AccessTokenIssuer.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Token;
+
+use Horde\Jwt\Signer\SignerInterface;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Server\Entity\AccessToken;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\AccessTokenRepository;
+
+final class AccessTokenIssuer
+{
+    public function __construct(
+        private readonly TokenEncoder $encoder,
+        private readonly SignerInterface $signer,
+        private readonly AccessTokenRepository $repository,
+        private readonly string $issuer,
+        private readonly int $ttl = 3600,
+    ) {}
+
+    /**
+     * @param Scope[] $scopes
+     * @return array<string, mixed>
+     */
+    public function issue(Client $client, ?string $identityId, array $scopes): array
+    {
+        $jti = bin2hex(random_bytes(16));
+        $scopeString = Scope::toSpaceSeparated($scopes);
+        $expiresAt = new \DateTimeImmutable("+{$this->ttl} seconds");
+
+        $claims = [
+            'iss' => $this->issuer,
+            'sub' => $identityId,
+            'aud' => $client->clientId,
+            'jti' => $jti,
+            'scope' => $scopeString,
+            'client_id' => $client->clientId,
+        ];
+
+        $token = $this->encoder->encode($claims, $this->signer, $this->ttl);
+
+        $entity = new AccessToken(
+            $jti,
+            $client->clientId,
+            $identityId,
+            $scopeString,
+            $expiresAt,
+        );
+        $this->repository->persist($entity);
+
+        $result = [
+            'access_token' => $token->toString(),
+            'token_type' => 'Bearer',
+            'expires_in' => $this->ttl,
+        ];
+
+        if ($scopeString !== '') {
+            $result['scope'] = $scopeString;
+        }
+
+        $result['_jti'] = $jti;
+
+        return $result;
+    }
+}

--- a/src/Server/Token/AccessTokenIssuer.php
+++ b/src/Server/Token/AccessTokenIssuer.php
@@ -19,6 +19,7 @@ use Horde\Oauth\Server\Entity\AccessToken;
 use Horde\Oauth\Server\Entity\Client;
 use Horde\Oauth\Server\Entity\Scope;
 use Horde\Oauth\Server\Repository\AccessTokenRepository;
+use DateTimeImmutable;
 
 final class AccessTokenIssuer
 {
@@ -38,7 +39,7 @@ final class AccessTokenIssuer
     {
         $jti = bin2hex(random_bytes(16));
         $scopeString = Scope::toSpaceSeparated($scopes);
-        $expiresAt = new \DateTimeImmutable("+{$this->ttl} seconds");
+        $expiresAt = new DateTimeImmutable("+{$this->ttl} seconds");
 
         $claims = [
             'iss' => $this->issuer,

--- a/src/Server/Token/RefreshTokenIssuer.php
+++ b/src/Server/Token/RefreshTokenIssuer.php
@@ -17,6 +17,7 @@ use Horde\Oauth\Server\Entity\Client;
 use Horde\Oauth\Server\Entity\RefreshToken;
 use Horde\Oauth\Server\Entity\Scope;
 use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+use DateTimeImmutable;
 
 final class RefreshTokenIssuer
 {
@@ -31,7 +32,7 @@ final class RefreshTokenIssuer
     public function issue(string $accessTokenId, Client $client, ?string $identityId, array $scopes): string
     {
         $tokenId = bin2hex(random_bytes(32));
-        $expiresAt = new \DateTimeImmutable("+{$this->ttl} seconds");
+        $expiresAt = new DateTimeImmutable("+{$this->ttl} seconds");
 
         $entity = new RefreshToken(
             $tokenId,

--- a/src/Server/Token/RefreshTokenIssuer.php
+++ b/src/Server/Token/RefreshTokenIssuer.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Server\Token;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\RefreshToken;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\RefreshTokenRepository;
+
+final class RefreshTokenIssuer
+{
+    public function __construct(
+        private readonly RefreshTokenRepository $repository,
+        private readonly int $ttl = 2592000,
+    ) {}
+
+    /**
+     * @param Scope[] $scopes
+     */
+    public function issue(string $accessTokenId, Client $client, ?string $identityId, array $scopes): string
+    {
+        $tokenId = bin2hex(random_bytes(32));
+        $expiresAt = new \DateTimeImmutable("+{$this->ttl} seconds");
+
+        $entity = new RefreshToken(
+            $tokenId,
+            $accessTokenId,
+            $client->clientId,
+            $identityId,
+            Scope::toSpaceSeparated($scopes),
+            $expiresAt,
+        );
+        $this->repository->persist($entity);
+
+        return $tokenId;
+    }
+}

--- a/test/Client/PkceGeneratorTest.php
+++ b/test/Client/PkceGeneratorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Client;
+
+use Horde\Jwt\Base64Url;
+use Horde\Oauth\Client\PkceGenerator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PkceGenerator::class)]
+final class PkceGeneratorTest extends TestCase
+{
+    public function testGenerateVerifierDefaultLength(): void
+    {
+        $verifier = PkceGenerator::generateVerifier();
+        self::assertSame(128, strlen($verifier));
+        self::assertMatchesRegularExpression('/^[A-Za-z0-9_-]+$/', $verifier);
+    }
+
+    public function testGenerateVerifierCustomLength(): void
+    {
+        $verifier = PkceGenerator::generateVerifier(64);
+        self::assertSame(64, strlen($verifier));
+    }
+
+    public function testGenerateVerifierMinimum43(): void
+    {
+        $verifier = PkceGenerator::generateVerifier(10);
+        self::assertSame(43, strlen($verifier));
+    }
+
+    public function testComputeChallengeS256(): void
+    {
+        $verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+        $challenge = PkceGenerator::computeChallenge($verifier, 'S256');
+        $expected = Base64Url::encode(hash('sha256', $verifier, true));
+        self::assertSame($expected, $challenge);
+    }
+
+    public function testComputeChallengePlain(): void
+    {
+        $verifier = 'my-plain-verifier';
+        self::assertSame($verifier, PkceGenerator::computeChallenge($verifier, 'plain'));
+    }
+
+    public function testVerifierAndChallengeRoundTrip(): void
+    {
+        $verifier = PkceGenerator::generateVerifier();
+        $challenge = PkceGenerator::computeChallenge($verifier);
+        $computed = Base64Url::encode(hash('sha256', $verifier, true));
+        self::assertSame($computed, $challenge);
+    }
+}

--- a/test/Client/ProviderConfigTest.php
+++ b/test/Client/ProviderConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Client;
+
+use Horde\Oauth\Client\ProviderConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProviderConfig::class)]
+final class ProviderConfigTest extends TestCase
+{
+    public function testFromArray(): void
+    {
+        $cfg = ProviderConfig::fromArray([
+            'issuer' => 'https://example.com',
+            'authorization_endpoint' => 'https://example.com/authorize',
+            'token_endpoint' => 'https://example.com/token',
+            'userinfo_endpoint' => 'https://example.com/userinfo',
+            'jwks_uri' => 'https://example.com/.well-known/jwks.json',
+            'scopes_supported' => ['openid', 'profile'],
+        ]);
+        self::assertSame('https://example.com', $cfg->issuer);
+        self::assertSame('https://example.com/authorize', $cfg->authorizationEndpoint);
+        self::assertSame('https://example.com/token', $cfg->tokenEndpoint);
+        self::assertSame('https://example.com/userinfo', $cfg->userinfoEndpoint);
+        self::assertSame('https://example.com/.well-known/jwks.json', $cfg->jwksUri);
+        self::assertSame(['openid', 'profile'], $cfg->scopesSupported);
+    }
+
+    public function testFromArrayDefaults(): void
+    {
+        $cfg = ProviderConfig::fromArray([]);
+        self::assertSame('', $cfg->issuer);
+        self::assertNull($cfg->userinfoEndpoint);
+        self::assertSame(['code'], $cfg->responseTypesSupported);
+    }
+
+    public function testToArray(): void
+    {
+        $cfg = new ProviderConfig(
+            'https://example.com',
+            '/auth',
+            '/token',
+            userinfoEndpoint: '/userinfo',
+            scopesSupported: ['openid'],
+        );
+        $arr = $cfg->toArray();
+        self::assertSame('https://example.com', $arr['issuer']);
+        self::assertSame('/userinfo', $arr['userinfo_endpoint']);
+        self::assertArrayNotHasKey('jwks_uri', $arr);
+    }
+}

--- a/test/Client/TokenSetTest.php
+++ b/test/Client/TokenSetTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Client;
+
+use Horde\Oauth\Client\TokenSet;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TokenSet::class)]
+final class TokenSetTest extends TestCase
+{
+    public function testFromArray(): void
+    {
+        $ts = TokenSet::fromArray([
+            'access_token' => 'at1',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+            'refresh_token' => 'rt1',
+            'scope' => 'openid',
+            'id_token' => 'idt1',
+        ]);
+        self::assertSame('at1', $ts->accessToken);
+        self::assertSame('Bearer', $ts->tokenType);
+        self::assertSame(3600, $ts->expiresIn);
+        self::assertSame('rt1', $ts->refreshToken);
+        self::assertSame('openid', $ts->scope);
+        self::assertSame('idt1', $ts->idToken);
+        self::assertNotNull($ts->receivedAt);
+    }
+
+    public function testFromArrayDefaults(): void
+    {
+        $ts = TokenSet::fromArray(['access_token' => 'at1']);
+        self::assertSame('Bearer', $ts->tokenType);
+        self::assertNull($ts->expiresIn);
+        self::assertNull($ts->refreshToken);
+    }
+
+    public function testIsExpired(): void
+    {
+        $ts = new TokenSet('at1', 'Bearer', 3600, receivedAt: time());
+        self::assertFalse($ts->isExpired());
+    }
+
+    public function testIsExpiredTrue(): void
+    {
+        $ts = new TokenSet('at1', 'Bearer', 10, receivedAt: time() - 100);
+        self::assertTrue($ts->isExpired());
+    }
+
+    public function testIsExpiredNoExpiry(): void
+    {
+        $ts = new TokenSet('at1', 'Bearer');
+        self::assertFalse($ts->isExpired());
+    }
+
+    public function testGetExpiresAt(): void
+    {
+        $now = time();
+        $ts = new TokenSet('at1', 'Bearer', 3600, receivedAt: $now);
+        self::assertSame($now + 3600, $ts->getExpiresAt());
+    }
+
+    public function testToArray(): void
+    {
+        $ts = new TokenSet('at1', 'Bearer', 3600, 'rt1', 'openid', 'idt1');
+        $arr = $ts->toArray();
+        self::assertSame('at1', $arr['access_token']);
+        self::assertArrayNotHasKey('receivedAt', $arr);
+    }
+}

--- a/test/ErrorResponseTest.php
+++ b/test/ErrorResponseTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\ErrorResponse;
+use Horde\Oauth\Exception\InvalidClientException;
+use Horde\Oauth\Exception\OAuthException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ErrorResponse::class)]
+final class ErrorResponseTest extends TestCase
+{
+    public function testToArrayMinimal(): void
+    {
+        $e = new OAuthException('server_error');
+        $arr = ErrorResponse::toArray($e);
+        self::assertSame(['error' => 'server_error'], $arr);
+    }
+
+    public function testToArrayWithDescriptionAndUri(): void
+    {
+        $e = new OAuthException('server_error', 'Something broke', 'https://example.com/err');
+        $arr = ErrorResponse::toArray($e);
+        self::assertSame('server_error', $arr['error']);
+        self::assertSame('Something broke', $arr['error_description']);
+        self::assertSame('https://example.com/err', $arr['error_uri']);
+    }
+
+    public function testToJson(): void
+    {
+        $e = new InvalidClientException('Unknown client');
+        $json = ErrorResponse::toJson($e);
+        $decoded = json_decode($json, true);
+        self::assertSame('invalid_client', $decoded['error']);
+        self::assertSame('Unknown client', $decoded['error_description']);
+    }
+
+    public function testToResponse(): void
+    {
+        $e = new InvalidClientException('Unknown client');
+        $response = ErrorResponse::toResponse($e, new ResponseFactory(), new StreamFactory());
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('invalid_client', $body['error']);
+    }
+}

--- a/test/Exception/OAuthExceptionTest.php
+++ b/test/Exception/OAuthExceptionTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Exception;
+
+use Horde\Oauth\Exception\AccessDeniedException;
+use Horde\Oauth\Exception\InvalidClientException;
+use Horde\Oauth\Exception\InvalidGrantException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Exception\InvalidScopeException;
+use Horde\Oauth\Exception\OAuthException;
+use Horde\Oauth\Exception\UnauthorizedClientException;
+use Horde\Oauth\Exception\UnsupportedGrantTypeException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(OAuthException::class)]
+#[CoversClass(AccessDeniedException::class)]
+#[CoversClass(InvalidClientException::class)]
+#[CoversClass(InvalidGrantException::class)]
+#[CoversClass(InvalidRequestException::class)]
+#[CoversClass(InvalidScopeException::class)]
+#[CoversClass(UnauthorizedClientException::class)]
+#[CoversClass(UnsupportedGrantTypeException::class)]
+final class OAuthExceptionTest extends TestCase
+{
+    public function testBaseExceptionCarriesErrorCode(): void
+    {
+        $e = new OAuthException('server_error', 'Something broke', 'https://example.com/err', 500);
+        self::assertSame('server_error', $e->getError());
+        self::assertSame('Something broke', $e->getErrorDescription());
+        self::assertSame('https://example.com/err', $e->getErrorUri());
+        self::assertSame(500, $e->getHttpStatusCode());
+    }
+
+    public function testBaseExceptionDefaults(): void
+    {
+        $e = new OAuthException('test_error');
+        self::assertSame('', $e->getErrorDescription());
+        self::assertSame('', $e->getErrorUri());
+        self::assertSame(400, $e->getHttpStatusCode());
+    }
+
+    public function testInvalidClientIs401(): void
+    {
+        $e = new InvalidClientException('bad client');
+        self::assertSame('invalid_client', $e->getError());
+        self::assertSame(401, $e->getHttpStatusCode());
+    }
+
+    public function testInvalidGrantIs400(): void
+    {
+        $e = new InvalidGrantException('bad grant');
+        self::assertSame('invalid_grant', $e->getError());
+        self::assertSame(400, $e->getHttpStatusCode());
+    }
+
+    public function testInvalidRequestIs400(): void
+    {
+        $e = new InvalidRequestException('bad request');
+        self::assertSame('invalid_request', $e->getError());
+        self::assertSame(400, $e->getHttpStatusCode());
+    }
+
+    public function testInvalidScopeIs400(): void
+    {
+        $e = new InvalidScopeException('bad scope');
+        self::assertSame('invalid_scope', $e->getError());
+        self::assertSame(400, $e->getHttpStatusCode());
+    }
+
+    public function testUnauthorizedClientIs400(): void
+    {
+        $e = new UnauthorizedClientException('not allowed');
+        self::assertSame('unauthorized_client', $e->getError());
+        self::assertSame(400, $e->getHttpStatusCode());
+    }
+
+    public function testUnsupportedGrantTypeIs400(): void
+    {
+        $e = new UnsupportedGrantTypeException('unknown');
+        self::assertSame('unsupported_grant_type', $e->getError());
+        self::assertSame(400, $e->getHttpStatusCode());
+    }
+
+    public function testAccessDeniedIs403(): void
+    {
+        $e = new AccessDeniedException('denied');
+        self::assertSame('access_denied', $e->getError());
+        self::assertSame(403, $e->getHttpStatusCode());
+    }
+
+    public function testPreviousExceptionChaining(): void
+    {
+        $prev = new RuntimeException('root');
+        $e = new OAuthException('test', 'desc', '', 400, $prev);
+        self::assertSame($prev, $e->getPrevious());
+    }
+}

--- a/test/Oidc/Handler/DiscoveryEndpointTest.php
+++ b/test/Oidc/Handler/DiscoveryEndpointTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Oidc\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Oidc\Handler\DiscoveryEndpoint;
+use Horde\Oauth\Server\ServerMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DiscoveryEndpoint::class)]
+final class DiscoveryEndpointTest extends TestCase
+{
+    public function testReturnsDiscoveryDocument(): void
+    {
+        $meta = new ServerMetadata(
+            'https://example.com',
+            '/authorize',
+            '/token',
+            jwksUri: 'https://example.com/.well-known/jwks.json',
+            userinfoEndpoint: 'https://example.com/userinfo',
+        );
+        $handler = new DiscoveryEndpoint($meta, new ResponseFactory(), new StreamFactory());
+        $response = $handler->handle(new ServerRequest('GET', 'https://example.com/.well-known/openid-configuration'));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('https://example.com', $body['issuer']);
+        self::assertSame('https://example.com/.well-known/jwks.json', $body['jwks_uri']);
+    }
+}

--- a/test/Oidc/Handler/JwksEndpointTest.php
+++ b/test/Oidc/Handler/JwksEndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Oidc\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Jwt\Key\PublicKey;
+use Horde\Oauth\Oidc\Handler\JwksEndpoint;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JwksEndpoint::class)]
+final class JwksEndpointTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    public function testReturnsJwksJson(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $pubKey = PublicKey::fromPrivateKey($rsaKey);
+        $handler = new JwksEndpoint($pubKey, new ResponseFactory(), new StreamFactory(), 'my-key-id');
+        $response = $handler->handle(new ServerRequest('GET', 'https://example.com/.well-known/jwks.json'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertArrayHasKey('keys', $body);
+        self::assertCount(1, $body['keys']);
+        $key = $body['keys'][0];
+        self::assertSame('my-key-id', $key['kid']);
+        self::assertSame('RS256', $key['alg']);
+        self::assertSame('RSA', $key['kty']);
+        self::assertArrayHasKey('n', $key);
+        self::assertArrayHasKey('e', $key);
+    }
+}

--- a/test/Oidc/Handler/UserinfoEndpointTest.php
+++ b/test/Oidc/Handler/UserinfoEndpointTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Oidc\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Oidc\ClaimsMapper;
+use Horde\Oauth\Oidc\Handler\UserinfoEndpoint;
+use Horde\Oauth\Oidc\ScopeClaimsMapping;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(UserinfoEndpoint::class)]
+final class UserinfoEndpointTest extends TestCase
+{
+    private UserinfoEndpoint $handler;
+
+    protected function setUp(): void
+    {
+        $claimsMapper = new class implements ClaimsMapper {
+            public function getClaims(string $identityId, array $claimNames): array
+            {
+                return array_intersect_key(
+                    ['name' => 'Test User', 'email' => 'test@example.com'],
+                    array_flip($claimNames),
+                );
+            }
+        };
+        $this->handler = new UserinfoEndpoint(
+            $claimsMapper,
+            new ScopeClaimsMapping(),
+            new ResponseFactory(),
+            new StreamFactory(),
+        );
+    }
+
+    public function testReturnsClaimsForAuthenticatedUser(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/userinfo'))
+            ->withAttribute('oauth_user_id', 'user1')
+            ->withAttribute('oauth_scopes', 'openid profile email');
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('user1', $body['sub']);
+        self::assertSame('Test User', $body['name']);
+        self::assertSame('test@example.com', $body['email']);
+    }
+
+    public function testReturns401WithoutUser(): void
+    {
+        $request = new ServerRequest('GET', 'https://example.com/userinfo');
+        $response = $this->handler->handle($request);
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString('Bearer', $response->getHeaderLine('WWW-Authenticate'));
+    }
+
+    public function testRespectsScopes(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/userinfo'))
+            ->withAttribute('oauth_user_id', 'user1')
+            ->withAttribute('oauth_scopes', 'openid profile');
+        $response = $this->handler->handle($request);
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('Test User', $body['name']);
+        self::assertArrayNotHasKey('email', $body);
+    }
+}

--- a/test/Oidc/IdTokenBuilderTest.php
+++ b/test/Oidc/IdTokenBuilderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Oidc;
+
+use Horde\Jwt\Base64Url;
+use Horde\Jwt\Key\PublicKey;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenDecoder;
+use Horde\Jwt\TokenEncoder;
+use Horde\Jwt\Verifier\Rs256Verifier;
+use Horde\Oauth\Oidc\ClaimsMapper;
+use Horde\Oauth\Oidc\IdTokenBuilder;
+use Horde\Oauth\Oidc\ScopeClaimsMapping;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IdTokenBuilder::class)]
+final class IdTokenBuilderTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private \Horde\Jwt\Key\PrivateKey $rsaKey;
+    private IdTokenBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->rsaKey = self::generateRsaKey();
+        $claimsMapper = new class implements ClaimsMapper {
+            public function getClaims(string $identityId, array $claimNames): array
+            {
+                $all = [
+                    'name' => 'Test User',
+                    'email' => 'test@example.com',
+                    'email_verified' => true,
+                ];
+                return array_intersect_key($all, array_flip($claimNames));
+            }
+        };
+        $this->builder = new IdTokenBuilder(
+            new TokenEncoder(),
+            new Rs256Signer($this->rsaKey),
+            $claimsMapper,
+            new ScopeClaimsMapping(),
+            'https://example.com',
+            3600,
+        );
+    }
+
+    public function testBuildProducesValidJwt(): void
+    {
+        $jwt = $this->builder->build('user1', 'c1', ['openid', 'profile'], 'nonce123');
+        $parts = explode('.', $jwt);
+        self::assertCount(3, $parts);
+    }
+
+    public function testBuildContainsStandardClaims(): void
+    {
+        $jwt = $this->builder->build('user1', 'c1', ['openid'], 'nonce123');
+        $decoder = new TokenDecoder();
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $token = $decoder->decode($jwt, $verifier, ['verify_exp' => true]);
+
+        self::assertSame('https://example.com', $token->getClaim('iss'));
+        self::assertSame('user1', $token->getSubject());
+        self::assertSame('c1', $token->getClaim('aud'));
+        self::assertSame('nonce123', $token->getClaim('nonce'));
+        self::assertNotNull($token->getClaim('auth_time'));
+    }
+
+    public function testBuildIncludesUserClaims(): void
+    {
+        $jwt = $this->builder->build('user1', 'c1', ['openid', 'email']);
+        $decoder = new TokenDecoder();
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $token = $decoder->decode($jwt, $verifier);
+        self::assertSame('test@example.com', $token->getClaim('email'));
+    }
+
+    public function testBuildWithAtHash(): void
+    {
+        $jwt = $this->builder->build('user1', 'c1', ['openid'], null, 'some-at-hash');
+        $decoder = new TokenDecoder();
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $token = $decoder->decode($jwt, $verifier);
+        self::assertSame('some-at-hash', $token->getClaim('at_hash'));
+    }
+
+    public function testBuildWithCodeHash(): void
+    {
+        $jwt = $this->builder->build('user1', 'c1', ['openid'], null, null, 'some-c-hash');
+        $decoder = new TokenDecoder();
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $token = $decoder->decode($jwt, $verifier);
+        self::assertSame('some-c-hash', $token->getClaim('c_hash'));
+    }
+
+    public function testComputeAtHash(): void
+    {
+        $hash = IdTokenBuilder::computeAtHash('access-token-value');
+        self::assertNotEmpty($hash);
+        self::assertMatchesRegularExpression('/^[A-Za-z0-9_-]+$/', $hash);
+
+        $fullHash = hash('sha256', 'access-token-value', true);
+        $expected = Base64Url::encode(substr($fullHash, 0, (int) (strlen($fullHash) / 2)));
+        self::assertSame($expected, $hash);
+    }
+
+    public function testNonceOmittedWhenNull(): void
+    {
+        $jwt = $this->builder->build('user1', 'c1', ['openid']);
+        $decoder = new TokenDecoder();
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $token = $decoder->decode($jwt, $verifier);
+        self::assertNull($token->getClaim('nonce'));
+    }
+}

--- a/test/Oidc/OidcServerTest.php
+++ b/test/Oidc/OidcServerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Oidc;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\StreamFactory;
+use Horde\Jwt\Key\PublicKey;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Oidc\ClaimsMapper;
+use Horde\Oauth\Oidc\IdTokenBuilder;
+use Horde\Oauth\Oidc\OidcServer;
+use Horde\Oauth\Oidc\ScopeClaimsMapping;
+use Horde\Oauth\Server\AuthorizationServer;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryConsentRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use Horde\Oauth\Server\ServerMetadata;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OidcServer::class)]
+final class OidcServerTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private OidcServer $oidcServer;
+
+    protected function setUp(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $pubKey = PublicKey::fromPrivateKey($rsaKey);
+        $signer = new Rs256Signer($rsaKey);
+        $encoder = new TokenEncoder();
+        $metadata = new ServerMetadata('https://example.com', '/authorize', '/token');
+
+        $claimsMapper = new class implements ClaimsMapper {
+            public function getClaims(string $identityId, array $claimNames): array
+            {
+                return ['name' => 'Test'];
+            }
+        };
+        $scopeMapping = new ScopeClaimsMapping();
+        $idTokenBuilder = new IdTokenBuilder($encoder, $signer, $claimsMapper, $scopeMapping, 'https://example.com');
+
+        $authServer = new AuthorizationServer(
+            new InMemoryClientRepository(),
+            new InMemoryAccessTokenRepository(),
+            new InMemoryRefreshTokenRepository(),
+            new InMemoryAuthorizationCodeRepository(),
+            new InMemoryScopeRepository(),
+            new InMemoryConsentRepository(),
+            $encoder,
+            $signer,
+            new ResponseFactory(),
+            new StreamFactory(),
+            $metadata,
+        );
+
+        $this->oidcServer = new OidcServer(
+            $authServer,
+            $idTokenBuilder,
+            $claimsMapper,
+            $scopeMapping,
+            $pubKey,
+            $metadata,
+            new ResponseFactory(),
+            new StreamFactory(),
+        );
+    }
+
+    public function testWrapTokenResponseAddsIdToken(): void
+    {
+        $tokenResponse = ['access_token' => 'at1', 'token_type' => 'Bearer'];
+        $result = $this->oidcServer->wrapTokenResponse($tokenResponse, 'user1', 'c1', ['openid'], 'nonce1');
+        self::assertArrayHasKey('id_token', $result);
+        $parts = explode('.', $result['id_token']);
+        self::assertCount(3, $parts);
+    }
+
+    public function testWrapTokenResponseSkipsWithoutOpenidScope(): void
+    {
+        $tokenResponse = ['access_token' => 'at1', 'token_type' => 'Bearer'];
+        $result = $this->oidcServer->wrapTokenResponse($tokenResponse, 'user1', 'c1', ['profile']);
+        self::assertArrayNotHasKey('id_token', $result);
+    }
+
+    public function testGetDiscoveryEndpoint(): void
+    {
+        $endpoint = $this->oidcServer->getDiscoveryEndpoint();
+        self::assertInstanceOf(\Psr\Http\Server\RequestHandlerInterface::class, $endpoint);
+    }
+
+    public function testGetJwksEndpoint(): void
+    {
+        $endpoint = $this->oidcServer->getJwksEndpoint('my-key');
+        self::assertInstanceOf(\Psr\Http\Server\RequestHandlerInterface::class, $endpoint);
+    }
+
+    public function testGetUserinfoEndpoint(): void
+    {
+        $endpoint = $this->oidcServer->getUserinfoEndpoint();
+        self::assertInstanceOf(\Psr\Http\Server\RequestHandlerInterface::class, $endpoint);
+    }
+}

--- a/test/Oidc/ScopeClaimsMappingTest.php
+++ b/test/Oidc/ScopeClaimsMappingTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Oidc;
+
+use Horde\Oauth\Oidc\ScopeClaimsMapping;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ScopeClaimsMapping::class)]
+final class ScopeClaimsMappingTest extends TestCase
+{
+    public function testDefaultProfileClaims(): void
+    {
+        $mapping = new ScopeClaimsMapping();
+        $claims = $mapping->getClaimsForScopes(['profile']);
+        self::assertContains('name', $claims);
+        self::assertContains('family_name', $claims);
+        self::assertContains('given_name', $claims);
+        self::assertContains('preferred_username', $claims);
+    }
+
+    public function testDefaultEmailClaims(): void
+    {
+        $mapping = new ScopeClaimsMapping();
+        $claims = $mapping->getClaimsForScopes(['email']);
+        self::assertSame(['email', 'email_verified'], $claims);
+    }
+
+    public function testMultipleScopes(): void
+    {
+        $mapping = new ScopeClaimsMapping();
+        $claims = $mapping->getClaimsForScopes(['profile', 'email']);
+        self::assertContains('name', $claims);
+        self::assertContains('email', $claims);
+    }
+
+    public function testUnknownScopeReturnsEmpty(): void
+    {
+        $mapping = new ScopeClaimsMapping();
+        self::assertSame([], $mapping->getClaimsForScopes(['openid']));
+    }
+
+    public function testCustomMapping(): void
+    {
+        $mapping = new ScopeClaimsMapping(['custom' => ['role', 'department']]);
+        $claims = $mapping->getClaimsForScopes(['custom']);
+        self::assertSame(['role', 'department'], $claims);
+        self::assertSame([], $mapping->getClaimsForScopes(['profile']));
+    }
+
+    public function testGetScopesForClaim(): void
+    {
+        $mapping = new ScopeClaimsMapping();
+        self::assertSame(['email'], $mapping->getScopesForClaim('email'));
+        self::assertSame(['profile'], $mapping->getScopesForClaim('name'));
+        self::assertSame([], $mapping->getScopesForClaim('nonexistent'));
+    }
+
+    public function testDeduplication(): void
+    {
+        $mapping = new ScopeClaimsMapping([
+            'a' => ['x', 'y'],
+            'b' => ['y', 'z'],
+        ]);
+        $claims = $mapping->getClaimsForScopes(['a', 'b']);
+        self::assertCount(3, $claims);
+    }
+}

--- a/test/RsaKeyHelper.php
+++ b/test/RsaKeyHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test;
+
+use Horde\Jwt\Key\PrivateKey;
+
+trait RsaKeyHelper
+{
+    private static function generateRsaKey(): PrivateKey
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($key, $pem);
+        return PrivateKey::fromString($pem);
+    }
+}

--- a/test/Server/AuthorizationServerTest.php
+++ b/test/Server/AuthorizationServerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\StreamFactory;
+use Horde\Jwt\Key\PublicKey;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Jwt\Verifier\Rs256Verifier;
+use Horde\Oauth\Server\AuthorizationServer;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Grant\AuthorizationCodeGrant;
+use Horde\Oauth\Server\Grant\ClientCredentialsGrant;
+use Horde\Oauth\Server\Grant\RefreshTokenGrant;
+use Horde\Oauth\Server\Handler\AuthorizationEndpoint;
+use Horde\Oauth\Server\Handler\IntrospectionEndpoint;
+use Horde\Oauth\Server\Handler\MetadataEndpoint;
+use Horde\Oauth\Server\Handler\RevocationEndpoint;
+use Horde\Oauth\Server\Handler\TokenEndpoint;
+use Horde\Oauth\Server\Middleware\BearerTokenMiddleware;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryConsentRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use Horde\Oauth\Server\ServerMetadata;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthorizationServer::class)]
+final class AuthorizationServerTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private AuthorizationServer $server;
+    private \Horde\Jwt\Key\PrivateKey $rsaKey;
+
+    protected function setUp(): void
+    {
+        $this->rsaKey = self::generateRsaKey();
+        $metadata = new ServerMetadata('https://example.com', '/authorize', '/token');
+        $this->server = new AuthorizationServer(
+            new InMemoryClientRepository(),
+            new InMemoryAccessTokenRepository(),
+            new InMemoryRefreshTokenRepository(),
+            new InMemoryAuthorizationCodeRepository(),
+            new InMemoryScopeRepository(new Scope('openid')),
+            new InMemoryConsentRepository(),
+            new TokenEncoder(),
+            new Rs256Signer($this->rsaKey),
+            new ResponseFactory(),
+            new StreamFactory(),
+            $metadata,
+        );
+    }
+
+    public function testCreateGrants(): void
+    {
+        $authCodeGrant = $this->server->createAuthorizationCodeGrant();
+        self::assertInstanceOf(AuthorizationCodeGrant::class, $authCodeGrant);
+
+        $ccGrant = $this->server->createClientCredentialsGrant();
+        self::assertInstanceOf(ClientCredentialsGrant::class, $ccGrant);
+
+        $rtGrant = $this->server->createRefreshTokenGrant();
+        self::assertInstanceOf(RefreshTokenGrant::class, $rtGrant);
+    }
+
+    public function testGetEndpoints(): void
+    {
+        $this->server->enableGrant($this->server->createClientCredentialsGrant());
+        self::assertInstanceOf(TokenEndpoint::class, $this->server->getTokenEndpoint());
+        self::assertInstanceOf(AuthorizationEndpoint::class, $this->server->getAuthorizationEndpoint());
+        self::assertInstanceOf(RevocationEndpoint::class, $this->server->getRevocationEndpoint());
+        self::assertInstanceOf(IntrospectionEndpoint::class, $this->server->getIntrospectionEndpoint());
+        self::assertInstanceOf(MetadataEndpoint::class, $this->server->getMetadataEndpoint());
+    }
+
+    public function testGetBearerMiddleware(): void
+    {
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $mw = $this->server->getBearerMiddleware($verifier);
+        self::assertInstanceOf(BearerTokenMiddleware::class, $mw);
+    }
+
+    public function testEnableGrant(): void
+    {
+        $grant = $this->server->createClientCredentialsGrant();
+        $this->server->enableGrant($grant);
+        $endpoint = $this->server->getTokenEndpoint();
+        self::assertInstanceOf(TokenEndpoint::class, $endpoint);
+    }
+}

--- a/test/Server/ClientAuthentication/ClientAuthenticatorChainTest.php
+++ b/test/Server/ClientAuthentication/ClientAuthenticatorChainTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\ClientAuthentication;
+
+use Horde\Http\ServerRequest;
+use Horde\Oauth\Exception\InvalidClientException;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretBasic;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretPost;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClientAuthenticatorChain::class)]
+final class ClientAuthenticatorChainTest extends TestCase
+{
+    private InMemoryClientRepository $repo;
+    private ClientAuthenticatorChain $chain;
+
+    protected function setUp(): void
+    {
+        $this->repo = new InMemoryClientRepository(
+            new Client(
+                'conf-client',
+                password_hash('secret', PASSWORD_BCRYPT),
+                'Confidential',
+                ['https://example.com/cb'],
+                ['authorization_code'],
+                'openid',
+                'confidential',
+                'client_secret_basic',
+            ),
+            new Client(
+                'pub-client',
+                null,
+                'Public',
+                ['https://example.com/cb'],
+                ['authorization_code'],
+                'openid',
+                'public',
+                'client_secret_post',
+            ),
+        );
+        $this->chain = new ClientAuthenticatorChain(
+            $this->repo,
+            new ClientSecretBasic(),
+            new ClientSecretPost(),
+        );
+    }
+
+    public function testAuthenticateConfidentialClient(): void
+    {
+        $encoded = base64_encode('conf-client:secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        $client = $this->chain->authenticateClient($request);
+        self::assertSame('conf-client', $client->clientId);
+    }
+
+    public function testAuthenticateClientWrongSecretThrows(): void
+    {
+        $encoded = base64_encode('conf-client:wrong');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        $this->expectException(InvalidClientException::class);
+        $this->chain->authenticateClient($request);
+    }
+
+    public function testAuthenticateClientUnknownThrows(): void
+    {
+        $encoded = base64_encode('unknown:secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        $this->expectException(InvalidClientException::class);
+        $this->chain->authenticateClient($request);
+    }
+
+    public function testAuthenticateClientNoCredentialsThrows(): void
+    {
+        $request = new ServerRequest('POST', 'https://example.com/token');
+        $this->expectException(InvalidClientException::class);
+        $this->chain->authenticateClient($request);
+    }
+
+    public function testAuthenticateClientOrPublicConfidential(): void
+    {
+        $encoded = base64_encode('conf-client:secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        $client = $this->chain->authenticateClientOrPublic($request);
+        self::assertSame('conf-client', $client->clientId);
+    }
+
+    public function testAuthenticateClientOrPublicFallback(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['client_id' => 'pub-client']);
+        $client = $this->chain->authenticateClientOrPublic($request);
+        self::assertSame('pub-client', $client->clientId);
+    }
+
+    public function testAuthenticateClientOrPublicConfidentialMustAuth(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['client_id' => 'conf-client']);
+        $this->expectException(InvalidClientException::class);
+        $this->chain->authenticateClientOrPublic($request);
+    }
+
+    public function testAuthenticateClientOrPublicNoIdThrows(): void
+    {
+        $request = new ServerRequest('POST', 'https://example.com/token');
+        $this->expectException(InvalidClientException::class);
+        $this->chain->authenticateClientOrPublic($request);
+    }
+
+    public function testAuthMethodMismatchThrows(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['client_id' => 'conf-client', 'client_secret' => 'secret']);
+        $this->expectException(InvalidClientException::class);
+        $this->expectExceptionMessage('Invalid authentication method');
+        $this->chain->authenticateClient($request);
+    }
+}

--- a/test/Server/ClientAuthentication/ClientSecretBasicTest.php
+++ b/test/Server/ClientAuthentication/ClientSecretBasicTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\ClientAuthentication;
+
+use Horde\Http\ServerRequest;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretBasic;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClientSecretBasic::class)]
+final class ClientSecretBasicTest extends TestCase
+{
+    private ClientSecretBasic $auth;
+
+    protected function setUp(): void
+    {
+        $this->auth = new ClientSecretBasic();
+    }
+
+    public function testGetMethod(): void
+    {
+        self::assertSame('client_secret_basic', $this->auth->getMethod());
+    }
+
+    public function testAuthenticateValid(): void
+    {
+        $encoded = base64_encode('my-client:my-secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        $result = $this->auth->authenticate($request);
+        self::assertSame(['my-client', 'my-secret'], $result);
+    }
+
+    public function testAuthenticateUrlDecodes(): void
+    {
+        $encoded = base64_encode(urlencode('client with spaces') . ':' . urlencode('secret:with:colons'));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        $result = $this->auth->authenticate($request);
+        self::assertSame('client with spaces', $result[0]);
+        self::assertSame('secret:with:colons', $result[1]);
+    }
+
+    public function testAuthenticateNoHeader(): void
+    {
+        $request = new ServerRequest('POST', 'https://example.com/token');
+        self::assertNull($this->auth->authenticate($request));
+    }
+
+    public function testAuthenticateBearerHeader(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', 'Bearer some-token');
+        self::assertNull($this->auth->authenticate($request));
+    }
+
+    public function testAuthenticateInvalidBase64(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', 'Basic !!!invalid!!!');
+        self::assertNull($this->auth->authenticate($request));
+    }
+
+    public function testAuthenticateNoColon(): void
+    {
+        $encoded = base64_encode('nocredentials');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}");
+        self::assertNull($this->auth->authenticate($request));
+    }
+}

--- a/test/Server/ClientAuthentication/ClientSecretPostTest.php
+++ b/test/Server/ClientAuthentication/ClientSecretPostTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\ClientAuthentication;
+
+use Horde\Http\ServerRequest;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretPost;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClientSecretPost::class)]
+final class ClientSecretPostTest extends TestCase
+{
+    private ClientSecretPost $auth;
+
+    protected function setUp(): void
+    {
+        $this->auth = new ClientSecretPost();
+    }
+
+    public function testGetMethod(): void
+    {
+        self::assertSame('client_secret_post', $this->auth->getMethod());
+    }
+
+    public function testAuthenticateWithSecret(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['client_id' => 'my-client', 'client_secret' => 'my-secret']);
+        $result = $this->auth->authenticate($request);
+        self::assertSame(['my-client', 'my-secret'], $result);
+    }
+
+    public function testAuthenticatePublicClient(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['client_id' => 'public-client']);
+        $result = $this->auth->authenticate($request);
+        self::assertSame('public-client', $result[0]);
+        self::assertNull($result[1]);
+    }
+
+    public function testAuthenticateNoParsedBody(): void
+    {
+        $request = new ServerRequest('POST', 'https://example.com/token');
+        self::assertNull($this->auth->authenticate($request));
+    }
+
+    public function testAuthenticateEmptyClientId(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['client_id' => '']);
+        self::assertNull($this->auth->authenticate($request));
+    }
+}

--- a/test/Server/Entity/AccessTokenTest.php
+++ b/test/Server/Entity/AccessTokenTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Entity;
+
+use Horde\Oauth\Server\Entity\AccessToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(AccessToken::class)]
+final class AccessTokenTest extends TestCase
+{
+    public function testNotExpired(): void
+    {
+        $token = new AccessToken('jti1', 'client1', 'user1', 'openid', new DateTimeImmutable('+1 hour'));
+        self::assertFalse($token->isExpired());
+        self::assertFalse($token->isRevoked());
+    }
+
+    public function testExpired(): void
+    {
+        $token = new AccessToken('jti1', 'client1', 'user1', 'openid', new DateTimeImmutable('-1 second'));
+        self::assertTrue($token->isExpired());
+    }
+
+    public function testRevoked(): void
+    {
+        $token = new AccessToken('jti1', 'client1', 'user1', 'openid', new DateTimeImmutable('+1 hour'), revoked: true);
+        self::assertTrue($token->isRevoked());
+    }
+
+    public function testGetScopes(): void
+    {
+        $token = new AccessToken('jti1', 'client1', 'user1', 'openid profile', new DateTimeImmutable('+1 hour'));
+        $scopes = $token->getScopes();
+        self::assertCount(2, $scopes);
+        self::assertSame('openid', $scopes[0]->identifier);
+        self::assertSame('profile', $scopes[1]->identifier);
+    }
+
+    public function testNullIdentity(): void
+    {
+        $token = new AccessToken('jti1', 'client1', null, 'api', new DateTimeImmutable('+1 hour'));
+        self::assertNull($token->identityId);
+    }
+}

--- a/test/Server/Entity/AuthorizationCodeTest.php
+++ b/test/Server/Entity/AuthorizationCodeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Entity;
+
+use Horde\Oauth\Server\Entity\AuthorizationCode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(AuthorizationCode::class)]
+final class AuthorizationCodeTest extends TestCase
+{
+    public function testNotExpiredNotUsed(): void
+    {
+        $code = new AuthorizationCode(
+            'abc123',
+            'client1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        );
+        self::assertFalse($code->isExpired());
+        self::assertFalse($code->isUsed());
+    }
+
+    public function testExpired(): void
+    {
+        $code = new AuthorizationCode(
+            'abc123',
+            'client1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('-1 second'),
+        );
+        self::assertTrue($code->isExpired());
+    }
+
+    public function testUsed(): void
+    {
+        $code = new AuthorizationCode(
+            'abc123',
+            'client1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+            used: true,
+        );
+        self::assertTrue($code->isUsed());
+    }
+
+    public function testPkceFields(): void
+    {
+        $code = new AuthorizationCode(
+            'abc123',
+            'client1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            'challenge123',
+            'S256',
+            'nonce-val',
+            new DateTimeImmutable('+10 minutes'),
+        );
+        self::assertSame('challenge123', $code->codeChallenge);
+        self::assertSame('S256', $code->codeChallengeMethod);
+        self::assertSame('nonce-val', $code->nonce);
+    }
+}

--- a/test/Server/Entity/ClientTest.php
+++ b/test/Server/Entity/ClientTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Entity;
+
+use Horde\Oauth\Server\Entity\Client;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Client::class)]
+final class ClientTest extends TestCase
+{
+    private function createClient(string $type = 'confidential', ?string $secretHash = null): Client
+    {
+        return new Client(
+            clientId: 'test-client',
+            clientSecretHash: $secretHash ?? password_hash('secret123', PASSWORD_BCRYPT),
+            clientName: 'Test App',
+            redirectUris: ['https://example.com/callback'],
+            grantTypes: ['authorization_code', 'refresh_token'],
+            scope: 'openid profile',
+            clientType: $type,
+        );
+    }
+
+    public function testConfidentialClient(): void
+    {
+        $client = $this->createClient();
+        self::assertTrue($client->isConfidential());
+        self::assertFalse($client->isPublic());
+    }
+
+    public function testPublicClient(): void
+    {
+        $client = $this->createClient('public', null);
+        self::assertTrue($client->isPublic());
+        self::assertFalse($client->isConfidential());
+    }
+
+    public function testVerifySecretCorrect(): void
+    {
+        $client = $this->createClient();
+        self::assertTrue($client->verifySecret('secret123'));
+    }
+
+    public function testVerifySecretWrong(): void
+    {
+        $client = $this->createClient();
+        self::assertFalse($client->verifySecret('wrong'));
+    }
+
+    public function testVerifySecretNullHash(): void
+    {
+        $client = $this->createClient('public', null);
+        self::assertFalse($client->verifySecret('anything'));
+    }
+
+    public function testSupportsGrantType(): void
+    {
+        $client = $this->createClient();
+        self::assertTrue($client->supportsGrantType('authorization_code'));
+        self::assertTrue($client->supportsGrantType('refresh_token'));
+        self::assertFalse($client->supportsGrantType('client_credentials'));
+    }
+
+    public function testHasRedirectUri(): void
+    {
+        $client = $this->createClient();
+        self::assertTrue($client->hasRedirectUri('https://example.com/callback'));
+        self::assertFalse($client->hasRedirectUri('https://evil.com/callback'));
+    }
+
+    public function testGetDefaultScopes(): void
+    {
+        $client = $this->createClient();
+        $scopes = $client->getDefaultScopes();
+        self::assertCount(2, $scopes);
+        self::assertSame('openid', $scopes[0]->identifier);
+        self::assertSame('profile', $scopes[1]->identifier);
+    }
+}

--- a/test/Server/Entity/ConsentTest.php
+++ b/test/Server/Entity/ConsentTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Entity;
+
+use Horde\Oauth\Server\Entity\Consent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(Consent::class)]
+final class ConsentTest extends TestCase
+{
+    public function testCoversScopeFull(): void
+    {
+        $consent = new Consent('user1', 'client1', 'openid profile email', new DateTimeImmutable());
+        self::assertTrue($consent->coversScope('openid profile'));
+        self::assertTrue($consent->coversScope('openid'));
+    }
+
+    public function testCoversScopePartial(): void
+    {
+        $consent = new Consent('user1', 'client1', 'openid profile', new DateTimeImmutable());
+        self::assertFalse($consent->coversScope('openid profile email'));
+    }
+
+    public function testCoversScopeEmpty(): void
+    {
+        $consent = new Consent('user1', 'client1', 'openid', new DateTimeImmutable());
+        self::assertTrue($consent->coversScope(''));
+    }
+}

--- a/test/Server/Entity/RefreshTokenTest.php
+++ b/test/Server/Entity/RefreshTokenTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Entity;
+
+use Horde\Oauth\Server\Entity\RefreshToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(RefreshToken::class)]
+final class RefreshTokenTest extends TestCase
+{
+    public function testNotExpiredNotRevoked(): void
+    {
+        $token = new RefreshToken('rt1', 'at1', 'client1', 'user1', 'openid', new DateTimeImmutable('+30 days'));
+        self::assertFalse($token->isExpired());
+        self::assertFalse($token->isRevoked());
+    }
+
+    public function testExpired(): void
+    {
+        $token = new RefreshToken('rt1', 'at1', 'client1', 'user1', 'openid', new DateTimeImmutable('-1 second'));
+        self::assertTrue($token->isExpired());
+    }
+
+    public function testRevoked(): void
+    {
+        $token = new RefreshToken('rt1', 'at1', 'client1', 'user1', 'openid', new DateTimeImmutable('+30 days'), revoked: true);
+        self::assertTrue($token->isRevoked());
+    }
+}

--- a/test/Server/Entity/ScopeTest.php
+++ b/test/Server/Entity/ScopeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Entity;
+
+use Horde\Oauth\Server\Entity\Scope;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Scope::class)]
+final class ScopeTest extends TestCase
+{
+    public function testConstructAndToString(): void
+    {
+        $scope = new Scope('openid');
+        self::assertSame('openid', $scope->identifier);
+        self::assertSame('openid', (string) $scope);
+    }
+
+    public function testFromString(): void
+    {
+        $scope = Scope::fromString('  email ');
+        self::assertSame('email', $scope->identifier);
+    }
+
+    public function testFromSpaceSeparated(): void
+    {
+        $scopes = Scope::fromSpaceSeparated('openid profile email');
+        self::assertCount(3, $scopes);
+        self::assertSame('openid', $scopes[0]->identifier);
+        self::assertSame('profile', $scopes[1]->identifier);
+        self::assertSame('email', $scopes[2]->identifier);
+    }
+
+    public function testFromSpaceSeparatedEmpty(): void
+    {
+        self::assertSame([], Scope::fromSpaceSeparated(''));
+        self::assertSame([], Scope::fromSpaceSeparated('   '));
+    }
+
+    public function testToSpaceSeparated(): void
+    {
+        $scopes = [new Scope('openid'), new Scope('profile')];
+        self::assertSame('openid profile', Scope::toSpaceSeparated($scopes));
+    }
+
+    public function testToSpaceSeparatedEmpty(): void
+    {
+        self::assertSame('', Scope::toSpaceSeparated([]));
+    }
+}

--- a/test/Server/Grant/AuthorizationCodeGrantTest.php
+++ b/test/Server/Grant/AuthorizationCodeGrantTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Grant;
+
+use Horde\Http\ServerRequest;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Client\PkceGenerator;
+use Horde\Oauth\Exception\InvalidGrantException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Server\Entity\AuthorizationCode;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Grant\AuthorizationCodeGrant;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Server\Token\RefreshTokenIssuer;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(AuthorizationCodeGrant::class)]
+final class AuthorizationCodeGrantTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private InMemoryAuthorizationCodeRepository $codeRepo;
+    private AuthorizationCodeGrant $grant;
+    private Client $client;
+
+    protected function setUp(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $atRepo = new InMemoryAccessTokenRepository();
+        $rtRepo = new InMemoryRefreshTokenRepository();
+        $this->codeRepo = new InMemoryAuthorizationCodeRepository();
+
+        $tokenIssuer = new AccessTokenIssuer(
+            new TokenEncoder(),
+            new Rs256Signer($rsaKey),
+            $atRepo,
+            'https://example.com',
+        );
+        $rtIssuer = new RefreshTokenIssuer($rtRepo);
+        $scopeRepo = new InMemoryScopeRepository(new Scope('openid'), new Scope('profile'));
+
+        $this->grant = new AuthorizationCodeGrant(
+            $this->codeRepo,
+            $tokenIssuer,
+            $rtIssuer,
+            $scopeRepo,
+        );
+        $this->client = new Client(
+            'c1',
+            password_hash('s', PASSWORD_BCRYPT),
+            'Test',
+            ['https://example.com/cb'],
+            ['authorization_code'],
+            'openid',
+            'confidential',
+        );
+    }
+
+    public function testGetIdentifier(): void
+    {
+        self::assertSame('authorization_code', $this->grant->getIdentifier());
+    }
+
+    public function testSuccessfulExchange(): void
+    {
+        $this->codeRepo->persist(new AuthorizationCode(
+            'valid-code',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            'nonce123',
+            new DateTimeImmutable('+10 minutes'),
+        ));
+
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody([
+                'grant_type' => 'authorization_code',
+                'code' => 'valid-code',
+                'redirect_uri' => 'https://example.com/cb',
+            ]);
+
+        $result = $this->grant->respondToTokenRequest($request, $this->client);
+        self::assertArrayHasKey('access_token', $result);
+        self::assertArrayHasKey('refresh_token', $result);
+        self::assertSame('user1', $result['_identity_id']);
+        self::assertSame('nonce123', $result['_nonce']);
+        self::assertTrue($this->codeRepo->isUsed('valid-code'));
+    }
+
+    public function testSuccessfulExchangeWithPkce(): void
+    {
+        $verifier = PkceGenerator::generateVerifier();
+        $challenge = PkceGenerator::computeChallenge($verifier);
+
+        $this->codeRepo->persist(new AuthorizationCode(
+            'pkce-code',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            $challenge,
+            'S256',
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        ));
+
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody([
+                'grant_type' => 'authorization_code',
+                'code' => 'pkce-code',
+                'redirect_uri' => 'https://example.com/cb',
+                'code_verifier' => $verifier,
+            ]);
+
+        $result = $this->grant->respondToTokenRequest($request, $this->client);
+        self::assertArrayHasKey('access_token', $result);
+    }
+
+    public function testPkceFailsWithWrongVerifier(): void
+    {
+        $challenge = PkceGenerator::computeChallenge('real-verifier');
+        $this->codeRepo->persist(new AuthorizationCode(
+            'pkce-code',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            $challenge,
+            'S256',
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        ));
+
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody([
+                'grant_type' => 'authorization_code',
+                'code' => 'pkce-code',
+                'redirect_uri' => 'https://example.com/cb',
+                'code_verifier' => 'wrong-verifier',
+            ]);
+
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('PKCE');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testMissingCodeThrows(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code']);
+        $this->expectException(InvalidRequestException::class);
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testInvalidCodeThrows(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code', 'code' => 'nonexistent']);
+        $this->expectException(InvalidGrantException::class);
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testExpiredCodeThrows(): void
+    {
+        $this->codeRepo->persist(new AuthorizationCode(
+            'expired',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('-1 second'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code', 'code' => 'expired', 'redirect_uri' => 'https://example.com/cb']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('expired');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testUsedCodeThrows(): void
+    {
+        $this->codeRepo->persist(new AuthorizationCode(
+            'used',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+            used: true,
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code', 'code' => 'used', 'redirect_uri' => 'https://example.com/cb']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('already been used');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testClientMismatchThrows(): void
+    {
+        $this->codeRepo->persist(new AuthorizationCode(
+            'code',
+            'other-client',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code', 'code' => 'code', 'redirect_uri' => 'https://example.com/cb']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('not issued to this client');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testRedirectUriMismatchThrows(): void
+    {
+        $this->codeRepo->persist(new AuthorizationCode(
+            'code',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code', 'code' => 'code', 'redirect_uri' => 'https://evil.com/cb']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('Redirect URI');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testPkceMissingVerifierThrows(): void
+    {
+        $this->codeRepo->persist(new AuthorizationCode(
+            'pkce',
+            'c1',
+            'user1',
+            'https://example.com/cb',
+            'openid',
+            'challenge',
+            'S256',
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'authorization_code', 'code' => 'pkce', 'redirect_uri' => 'https://example.com/cb']);
+        $this->expectException(InvalidRequestException::class);
+        $this->expectExceptionMessage('code_verifier');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+}

--- a/test/Server/Grant/ClientCredentialsGrantTest.php
+++ b/test/Server/Grant/ClientCredentialsGrantTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Grant;
+
+use Horde\Http\ServerRequest;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Grant\ClientCredentialsGrant;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClientCredentialsGrant::class)]
+final class ClientCredentialsGrantTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private ClientCredentialsGrant $grant;
+
+    protected function setUp(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $tokenIssuer = new AccessTokenIssuer(
+            new TokenEncoder(),
+            new Rs256Signer($rsaKey),
+            new InMemoryAccessTokenRepository(),
+            'https://example.com',
+        );
+        $scopeRepo = new InMemoryScopeRepository(new Scope('api'), new Scope('read'));
+        $this->grant = new ClientCredentialsGrant($tokenIssuer, $scopeRepo);
+    }
+
+    public function testGetIdentifier(): void
+    {
+        self::assertSame('client_credentials', $this->grant->getIdentifier());
+    }
+
+    public function testRespondWithScope(): void
+    {
+        $client = new Client('c1', null, 'Test', [], ['client_credentials'], 'api', 'confidential');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'client_credentials', 'scope' => 'api read']);
+        $result = $this->grant->respondToTokenRequest($request, $client);
+
+        self::assertArrayHasKey('access_token', $result);
+        self::assertSame('Bearer', $result['token_type']);
+        self::assertSame('api read', $result['scope']);
+        self::assertArrayNotHasKey('_jti', $result);
+    }
+
+    public function testRespondDefaultScope(): void
+    {
+        $client = new Client('c1', null, 'Test', [], ['client_credentials'], 'api', 'confidential');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'client_credentials']);
+        $result = $this->grant->respondToTokenRequest($request, $client);
+        self::assertSame('api', $result['scope']);
+    }
+}

--- a/test/Server/Grant/RefreshTokenGrantTest.php
+++ b/test/Server/Grant/RefreshTokenGrantTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Grant;
+
+use Horde\Http\ServerRequest;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Exception\InvalidGrantException;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\RefreshToken;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Grant\RefreshTokenGrant;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Server\Token\RefreshTokenIssuer;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(RefreshTokenGrant::class)]
+final class RefreshTokenGrantTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private InMemoryAccessTokenRepository $atRepo;
+    private InMemoryRefreshTokenRepository $rtRepo;
+    private RefreshTokenGrant $grant;
+    private Client $client;
+
+    protected function setUp(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $this->atRepo = new InMemoryAccessTokenRepository();
+        $this->rtRepo = new InMemoryRefreshTokenRepository();
+        $scopeRepo = new InMemoryScopeRepository(new Scope('openid'), new Scope('profile'));
+
+        $tokenIssuer = new AccessTokenIssuer(
+            new TokenEncoder(),
+            new Rs256Signer($rsaKey),
+            $this->atRepo,
+            'https://example.com',
+        );
+        $rtIssuer = new RefreshTokenIssuer($this->rtRepo);
+
+        $this->grant = new RefreshTokenGrant(
+            $this->rtRepo,
+            $this->atRepo,
+            $tokenIssuer,
+            $rtIssuer,
+            $scopeRepo,
+        );
+        $this->client = new Client(
+            'c1',
+            password_hash('s', PASSWORD_BCRYPT),
+            'Test',
+            ['https://example.com/cb'],
+            ['refresh_token'],
+            'openid',
+            'confidential',
+        );
+    }
+
+    public function testGetIdentifier(): void
+    {
+        self::assertSame('refresh_token', $this->grant->getIdentifier());
+    }
+
+    public function testSuccessfulRefresh(): void
+    {
+        $this->rtRepo->persist(new RefreshToken(
+            'rt1',
+            'at1',
+            'c1',
+            'user1',
+            'openid profile',
+            new DateTimeImmutable('+30 days'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token', 'refresh_token' => 'rt1']);
+        $result = $this->grant->respondToTokenRequest($request, $this->client);
+
+        self::assertArrayHasKey('access_token', $result);
+        self::assertArrayHasKey('refresh_token', $result);
+        self::assertTrue($this->rtRepo->isRevoked('rt1'));
+    }
+
+    public function testScopeNarrowing(): void
+    {
+        $this->rtRepo->persist(new RefreshToken(
+            'rt1',
+            'at1',
+            'c1',
+            'user1',
+            'openid profile',
+            new DateTimeImmutable('+30 days'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token', 'refresh_token' => 'rt1', 'scope' => 'openid']);
+        $result = $this->grant->respondToTokenRequest($request, $this->client);
+        self::assertSame('openid', $result['scope']);
+    }
+
+    public function testScopeEscalationThrows(): void
+    {
+        $this->rtRepo->persist(new RefreshToken(
+            'rt1',
+            'at1',
+            'c1',
+            'user1',
+            'openid',
+            new DateTimeImmutable('+30 days'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token', 'refresh_token' => 'rt1', 'scope' => 'openid profile']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('exceeds');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testMissingRefreshTokenThrows(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token']);
+        $this->expectException(InvalidRequestException::class);
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testRevokedRefreshTokenThrows(): void
+    {
+        $this->rtRepo->persist(new RefreshToken(
+            'rt1',
+            'at1',
+            'c1',
+            'user1',
+            'openid',
+            new DateTimeImmutable('+30 days'),
+            revoked: true,
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token', 'refresh_token' => 'rt1']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('revoked');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testExpiredRefreshTokenThrows(): void
+    {
+        $this->rtRepo->persist(new RefreshToken(
+            'rt1',
+            'at1',
+            'c1',
+            'user1',
+            'openid',
+            new DateTimeImmutable('-1 second'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token', 'refresh_token' => 'rt1']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('expired');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+
+    public function testClientMismatchThrows(): void
+    {
+        $this->rtRepo->persist(new RefreshToken(
+            'rt1',
+            'at1',
+            'other-client',
+            'user1',
+            'openid',
+            new DateTimeImmutable('+30 days'),
+        ));
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withParsedBody(['grant_type' => 'refresh_token', 'refresh_token' => 'rt1']);
+        $this->expectException(InvalidGrantException::class);
+        $this->expectExceptionMessage('not issued to this client');
+        $this->grant->respondToTokenRequest($request, $this->client);
+    }
+}

--- a/test/Server/Handler/AuthorizationEndpointTest.php
+++ b/test/Server/Handler/AuthorizationEndpointTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Handler\AuthorizationEndpoint;
+use Horde\Oauth\Server\AuthorizationResult;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAuthorizationCodeRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AuthorizationEndpoint::class)]
+final class AuthorizationEndpointTest extends TestCase
+{
+    private AuthorizationEndpoint $handler;
+    private InMemoryAuthorizationCodeRepository $codeRepo;
+
+    protected function setUp(): void
+    {
+        $client = new Client(
+            'c1',
+            null,
+            'Test App',
+            ['https://example.com/cb'],
+            ['authorization_code'],
+            'openid profile',
+            'public',
+        );
+        $clientRepo = new InMemoryClientRepository($client);
+        $scopeRepo = new InMemoryScopeRepository(new Scope('openid'), new Scope('profile'));
+        $this->codeRepo = new InMemoryAuthorizationCodeRepository();
+        $this->handler = new AuthorizationEndpoint(
+            $clientRepo,
+            $scopeRepo,
+            $this->codeRepo,
+            new ResponseFactory(),
+            new StreamFactory(),
+        );
+    }
+
+    public function testValidateAuthorizationRequest(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/authorize'))
+            ->withQueryParams([
+                'response_type' => 'code',
+                'client_id' => 'c1',
+                'redirect_uri' => 'https://example.com/cb',
+                'scope' => 'openid',
+                'state' => 'xyz',
+                'nonce' => 'n1',
+            ]);
+        $authRequest = $this->handler->validateAuthorizationRequest($request);
+        self::assertSame('c1', $authRequest->client->clientId);
+        self::assertSame('xyz', $authRequest->state);
+        self::assertSame('n1', $authRequest->nonce);
+    }
+
+    public function testValidateDefaultsRedirectUri(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/authorize'))
+            ->withQueryParams([
+                'response_type' => 'code',
+                'client_id' => 'c1',
+                'scope' => 'openid',
+            ]);
+        $authRequest = $this->handler->validateAuthorizationRequest($request);
+        self::assertSame('https://example.com/cb', $authRequest->redirectUri);
+    }
+
+    public function testCompleteApproved(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/authorize'))
+            ->withQueryParams([
+                'response_type' => 'code',
+                'client_id' => 'c1',
+                'redirect_uri' => 'https://example.com/cb',
+                'scope' => 'openid',
+                'state' => 'xyz',
+            ]);
+        $authRequest = $this->handler->validateAuthorizationRequest($request);
+        $result = new AuthorizationResult($authRequest, true, 'user1');
+        $response = $this->handler->completeAuthorizationRequest($result);
+
+        self::assertSame(302, $response->getStatusCode());
+        $location = $response->getHeaderLine('Location');
+        self::assertStringContainsString('code=', $location);
+        self::assertStringContainsString('state=xyz', $location);
+    }
+
+    public function testCompleteDenied(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/authorize'))
+            ->withQueryParams([
+                'response_type' => 'code',
+                'client_id' => 'c1',
+                'redirect_uri' => 'https://example.com/cb',
+                'state' => 'xyz',
+            ]);
+        $authRequest = $this->handler->validateAuthorizationRequest($request);
+        $result = new AuthorizationResult($authRequest, false, null);
+        $response = $this->handler->completeAuthorizationRequest($result);
+
+        self::assertSame(302, $response->getStatusCode());
+        $location = $response->getHeaderLine('Location');
+        self::assertStringContainsString('error=access_denied', $location);
+        self::assertStringContainsString('state=xyz', $location);
+    }
+
+    public function testHandleReturnsJson(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/authorize'))
+            ->withQueryParams([
+                'response_type' => 'code',
+                'client_id' => 'c1',
+                'redirect_uri' => 'https://example.com/cb',
+                'scope' => 'openid',
+            ]);
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('c1', $body['client_id']);
+    }
+
+    public function testHandleInvalidRequest(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/authorize'))
+            ->withQueryParams(['response_type' => 'token']);
+        $response = $this->handler->handle($request);
+        self::assertSame(400, $response->getStatusCode());
+    }
+}

--- a/test/Server/Handler/IntrospectionEndpointTest.php
+++ b/test/Server/Handler/IntrospectionEndpointTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretBasic;
+use Horde\Oauth\Server\Entity\AccessToken;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Handler\IntrospectionEndpoint;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(IntrospectionEndpoint::class)]
+final class IntrospectionEndpointTest extends TestCase
+{
+    private IntrospectionEndpoint $handler;
+    private InMemoryAccessTokenRepository $atRepo;
+
+    protected function setUp(): void
+    {
+        $client = new Client(
+            'c1',
+            password_hash('s', PASSWORD_BCRYPT),
+            'Test',
+            [],
+            ['client_credentials'],
+            'api',
+            'confidential',
+        );
+        $clientRepo = new InMemoryClientRepository($client);
+        $chain = new ClientAuthenticatorChain($clientRepo, new ClientSecretBasic());
+        $this->atRepo = new InMemoryAccessTokenRepository();
+        $rtRepo = new InMemoryRefreshTokenRepository();
+        $this->handler = new IntrospectionEndpoint($chain, $this->atRepo, $rtRepo, new ResponseFactory(), new StreamFactory());
+    }
+
+    private function authHeader(): string
+    {
+        return 'Basic ' . base64_encode('c1:s');
+    }
+
+    public function testActiveToken(): void
+    {
+        $this->atRepo->persist(new AccessToken('jti1', 'c1', 'user1', 'api', new DateTimeImmutable('+1 hour')));
+        $request = (new ServerRequest('POST', 'https://example.com/introspect'))
+            ->withHeader('Authorization', $this->authHeader())
+            ->withParsedBody(['token' => 'jti1']);
+        $response = $this->handler->handle($request);
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertTrue($body['active']);
+        self::assertSame('api', $body['scope']);
+        self::assertSame('Bearer', $body['token_type']);
+    }
+
+    public function testInactiveToken(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/introspect'))
+            ->withHeader('Authorization', $this->authHeader())
+            ->withParsedBody(['token' => 'nonexistent']);
+        $response = $this->handler->handle($request);
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['active']);
+    }
+
+    public function testRevokedTokenInactive(): void
+    {
+        $this->atRepo->persist(new AccessToken('jti1', 'c1', 'user1', 'api', new DateTimeImmutable('+1 hour'), revoked: true));
+        $request = (new ServerRequest('POST', 'https://example.com/introspect'))
+            ->withHeader('Authorization', $this->authHeader())
+            ->withParsedBody(['token' => 'jti1']);
+        $response = $this->handler->handle($request);
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['active']);
+    }
+
+    public function testMissingTokenReturnsInactive(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/introspect'))
+            ->withHeader('Authorization', $this->authHeader())
+            ->withParsedBody([]);
+        $response = $this->handler->handle($request);
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['active']);
+    }
+
+    public function testUnauthenticatedReturnsError(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/introspect'))
+            ->withParsedBody(['token' => 'jti1']);
+        $response = $this->handler->handle($request);
+        self::assertSame(401, $response->getStatusCode());
+    }
+}

--- a/test/Server/Handler/MetadataEndpointTest.php
+++ b/test/Server/Handler/MetadataEndpointTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Server\Handler\MetadataEndpoint;
+use Horde\Oauth\Server\ServerMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MetadataEndpoint::class)]
+final class MetadataEndpointTest extends TestCase
+{
+    public function testReturnsMetadataAsJson(): void
+    {
+        $meta = new ServerMetadata('https://example.com', '/authorize', '/token');
+        $handler = new MetadataEndpoint($meta, new ResponseFactory(), new StreamFactory());
+        $response = $handler->handle(new ServerRequest('GET', 'https://example.com/.well-known/oauth-authorization-server'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('https://example.com', $body['issuer']);
+    }
+}

--- a/test/Server/Handler/RevocationEndpointTest.php
+++ b/test/Server/Handler/RevocationEndpointTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretBasic;
+use Horde\Oauth\Server\Entity\AccessToken;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Handler\RevocationEndpoint;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(RevocationEndpoint::class)]
+final class RevocationEndpointTest extends TestCase
+{
+    private RevocationEndpoint $handler;
+    private InMemoryAccessTokenRepository $atRepo;
+
+    protected function setUp(): void
+    {
+        $client = new Client('c1', password_hash('s', PASSWORD_BCRYPT), 'Test', [], ['client_credentials'], 'api', 'confidential');
+        $clientRepo = new InMemoryClientRepository($client);
+        $chain = new ClientAuthenticatorChain($clientRepo, new ClientSecretBasic());
+        $this->atRepo = new InMemoryAccessTokenRepository();
+        $rtRepo = new InMemoryRefreshTokenRepository();
+        $this->handler = new RevocationEndpoint($chain, $this->atRepo, $rtRepo, new ResponseFactory(), new StreamFactory());
+    }
+
+    private function authHeader(): string
+    {
+        return 'Basic ' . base64_encode('c1:s');
+    }
+
+    public function testRevokesAccessToken(): void
+    {
+        $this->atRepo->persist(new AccessToken('jti1', 'c1', 'user1', 'api', new DateTimeImmutable('+1 hour')));
+        $request = (new ServerRequest('POST', 'https://example.com/revoke'))
+            ->withHeader('Authorization', $this->authHeader())
+            ->withParsedBody(['token' => 'jti1', 'token_type_hint' => 'access_token']);
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($this->atRepo->isRevoked('jti1'));
+    }
+
+    public function testRevokeMissingTokenReturns200(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/revoke'))
+            ->withHeader('Authorization', $this->authHeader())
+            ->withParsedBody([]);
+        $response = $this->handler->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testUnauthenticatedReturnsError(): void
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/revoke'))
+            ->withParsedBody(['token' => 'jti1']);
+        $response = $this->handler->handle($request);
+        self::assertSame(401, $response->getStatusCode());
+    }
+}

--- a/test/Server/Handler/TokenEndpointTest.php
+++ b/test/Server/Handler/TokenEndpointTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Handler;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Server\ClientAuthentication\ClientAuthenticatorChain;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretBasic;
+use Horde\Oauth\Server\ClientAuthentication\ClientSecretPost;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Grant\ClientCredentialsGrant;
+use Horde\Oauth\Server\Handler\TokenEndpoint;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TokenEndpoint::class)]
+final class TokenEndpointTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private TokenEndpoint $handler;
+
+    protected function setUp(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $client = new Client(
+            'c1',
+            password_hash('secret', PASSWORD_BCRYPT),
+            'Test',
+            [],
+            ['client_credentials'],
+            'api',
+            'confidential',
+        );
+        $clientRepo = new InMemoryClientRepository($client);
+        $chain = new ClientAuthenticatorChain($clientRepo, new ClientSecretBasic(), new ClientSecretPost());
+        $tokenIssuer = new AccessTokenIssuer(
+            new TokenEncoder(),
+            new Rs256Signer($rsaKey),
+            new InMemoryAccessTokenRepository(),
+            'https://example.com',
+        );
+        $scopeRepo = new InMemoryScopeRepository(new Scope('api'));
+        $grant = new ClientCredentialsGrant($tokenIssuer, $scopeRepo);
+        $this->handler = new TokenEndpoint($chain, new ResponseFactory(), new StreamFactory(), $grant);
+    }
+
+    public function testSuccessfulTokenRequest(): void
+    {
+        $encoded = base64_encode('c1:secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}")
+            ->withParsedBody(['grant_type' => 'client_credentials', 'scope' => 'api']);
+        $response = $this->handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertArrayHasKey('access_token', $body);
+        self::assertSame('Bearer', $body['token_type']);
+        self::assertArrayNotHasKey('_jti', $body);
+    }
+
+    public function testMissingGrantType(): void
+    {
+        $encoded = base64_encode('c1:secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}")
+            ->withParsedBody([]);
+        $response = $this->handler->handle($request);
+        self::assertSame(400, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('invalid_request', $body['error']);
+    }
+
+    public function testUnsupportedGrantType(): void
+    {
+        $encoded = base64_encode('c1:secret');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}")
+            ->withParsedBody(['grant_type' => 'password']);
+        $response = $this->handler->handle($request);
+        self::assertSame(400, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('unsupported_grant_type', $body['error']);
+    }
+
+    public function testInvalidClientCredentials(): void
+    {
+        $encoded = base64_encode('c1:wrong');
+        $request = (new ServerRequest('POST', 'https://example.com/token'))
+            ->withHeader('Authorization', "Basic {$encoded}")
+            ->withParsedBody(['grant_type' => 'client_credentials']);
+        $response = $this->handler->handle($request);
+        self::assertSame(401, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('invalid_client', $body['error']);
+    }
+}

--- a/test/Server/Middleware/BearerTokenMiddlewareTest.php
+++ b/test/Server/Middleware/BearerTokenMiddlewareTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Middleware;
+
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\Http\StreamFactory;
+use Horde\Jwt\Key\PrivateKey;
+use Horde\Jwt\Key\PublicKey;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenDecoder;
+use Horde\Jwt\TokenEncoder;
+use Horde\Jwt\Verifier\Rs256Verifier;
+use Horde\Oauth\Server\Entity\AccessToken;
+use Horde\Oauth\Server\Middleware\BearerTokenMiddleware;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Test\RsaKeyHelper;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(BearerTokenMiddleware::class)]
+final class BearerTokenMiddlewareTest extends TestCase
+{
+    use RsaKeyHelper;
+
+    private PrivateKey $rsaKey;
+    private BearerTokenMiddleware $middleware;
+    private InMemoryAccessTokenRepository $tokenRepo;
+
+    protected function setUp(): void
+    {
+        $this->rsaKey = self::generateRsaKey();
+        $this->tokenRepo = new InMemoryAccessTokenRepository();
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $this->middleware = new BearerTokenMiddleware(
+            new TokenDecoder(),
+            $verifier,
+            $this->tokenRepo,
+            new ResponseFactory(),
+            new StreamFactory(),
+        );
+    }
+
+    private function makeToken(string $jti = 'jti1', string $sub = 'user1', string $scope = 'openid'): string
+    {
+        $encoder = new TokenEncoder();
+        $signer = new Rs256Signer($this->rsaKey);
+        $token = $encoder->encode([
+            'sub' => $sub,
+            'jti' => $jti,
+            'client_id' => 'c1',
+            'scope' => $scope,
+        ], $signer, 3600);
+        return $token->toString();
+    }
+
+    private function nextHandler(): RequestHandlerInterface
+    {
+        return new class implements RequestHandlerInterface {
+            public ?ServerRequestInterface $receivedRequest = null;
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->receivedRequest = $request;
+                return (new ResponseFactory())->createResponse(200);
+            }
+        };
+    }
+
+    public function testValidToken(): void
+    {
+        $jwt = $this->makeToken();
+        $request = (new ServerRequest('GET', 'https://example.com/resource'))
+            ->withHeader('Authorization', "Bearer {$jwt}");
+        $next = $this->nextHandler();
+        $response = $this->middleware->process($request, $next);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($next->receivedRequest);
+        self::assertSame('user1', $next->receivedRequest->getAttribute('oauth_user_id'));
+        self::assertSame('c1', $next->receivedRequest->getAttribute('oauth_client_id'));
+        self::assertSame('openid', $next->receivedRequest->getAttribute('oauth_scopes'));
+    }
+
+    public function testRevokedTokenRejects(): void
+    {
+        $jwt = $this->makeToken('revoked-jti');
+        $this->tokenRepo->persist(new AccessToken('revoked-jti', 'c1', 'user1', 'openid', new DateTimeImmutable('+1 hour')));
+        $this->tokenRepo->revoke('revoked-jti');
+
+        $request = (new ServerRequest('GET', 'https://example.com/resource'))
+            ->withHeader('Authorization', "Bearer {$jwt}");
+        $response = $this->middleware->process($request, $this->nextHandler());
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString('Bearer', $response->getHeaderLine('WWW-Authenticate'));
+    }
+
+    public function testMissingTokenWhenRequired(): void
+    {
+        $request = new ServerRequest('GET', 'https://example.com/resource');
+        $response = $this->middleware->process($request, $this->nextHandler());
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testMissingTokenWhenOptional(): void
+    {
+        $verifier = new Rs256Verifier(PublicKey::fromPrivateKey($this->rsaKey));
+        $middleware = new BearerTokenMiddleware(
+            new TokenDecoder(),
+            $verifier,
+            $this->tokenRepo,
+            new ResponseFactory(),
+            new StreamFactory(),
+            required: false,
+        );
+        $request = new ServerRequest('GET', 'https://example.com/resource');
+        $next = $this->nextHandler();
+        $response = $middleware->process($request, $next);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotNull($next->receivedRequest);
+    }
+
+    public function testInvalidJwtRejects(): void
+    {
+        $request = (new ServerRequest('GET', 'https://example.com/resource'))
+            ->withHeader('Authorization', 'Bearer not.a.jwt');
+        $response = $this->middleware->process($request, $this->nextHandler());
+        self::assertSame(401, $response->getStatusCode());
+    }
+}

--- a/test/Server/Pkce/PkceVerifierTest.php
+++ b/test/Server/Pkce/PkceVerifierTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Pkce;
+
+use Horde\Jwt\Base64Url;
+use Horde\Oauth\Exception\InvalidRequestException;
+use Horde\Oauth\Server\Pkce\PkceVerifier;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PkceVerifier::class)]
+final class PkceVerifierTest extends TestCase
+{
+    public function testS256Succeeds(): void
+    {
+        $verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+        $challenge = Base64Url::encode(hash('sha256', $verifier, true));
+        self::assertTrue(PkceVerifier::verify($verifier, $challenge, 'S256'));
+    }
+
+    public function testS256FailsWithWrongVerifier(): void
+    {
+        $challenge = Base64Url::encode(hash('sha256', 'correct-verifier', true));
+        self::assertFalse(PkceVerifier::verify('wrong-verifier', $challenge, 'S256'));
+    }
+
+    public function testPlainSucceeds(): void
+    {
+        $verifier = 'my-plain-verifier';
+        self::assertTrue(PkceVerifier::verify($verifier, $verifier, 'plain'));
+    }
+
+    public function testPlainFails(): void
+    {
+        self::assertFalse(PkceVerifier::verify('a', 'b', 'plain'));
+    }
+
+    public function testUnsupportedMethodThrows(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        PkceVerifier::verify('a', 'b', 'unsupported');
+    }
+
+    public function testIsValidMethod(): void
+    {
+        self::assertTrue(PkceVerifier::isValidMethod('S256'));
+        self::assertTrue(PkceVerifier::isValidMethod('plain'));
+        self::assertFalse(PkceVerifier::isValidMethod('RS256'));
+    }
+}

--- a/test/Server/Repository/InMemory/InMemoryAccessTokenRepositoryTest.php
+++ b/test/Server/Repository/InMemory/InMemoryAccessTokenRepositoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\AccessToken;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(InMemoryAccessTokenRepository::class)]
+final class InMemoryAccessTokenRepositoryTest extends TestCase
+{
+    public function testPersistAndFind(): void
+    {
+        $repo = new InMemoryAccessTokenRepository();
+        $token = new AccessToken('jti1', 'c1', 'u1', 'openid', new DateTimeImmutable('+1 hour'));
+        $repo->persist($token);
+        self::assertSame($token, $repo->findById('jti1'));
+        self::assertNull($repo->findById('missing'));
+    }
+
+    public function testRevokeAndIsRevoked(): void
+    {
+        $repo = new InMemoryAccessTokenRepository();
+        $token = new AccessToken('jti1', 'c1', 'u1', 'openid', new DateTimeImmutable('+1 hour'));
+        $repo->persist($token);
+
+        self::assertFalse($repo->isRevoked('jti1'));
+        $repo->revoke('jti1');
+        self::assertTrue($repo->isRevoked('jti1'));
+
+        $found = $repo->findById('jti1');
+        self::assertTrue($found->revoked);
+    }
+
+    public function testRevokeNonExistent(): void
+    {
+        $repo = new InMemoryAccessTokenRepository();
+        $repo->revoke('missing');
+        self::assertFalse($repo->isRevoked('missing'));
+    }
+}

--- a/test/Server/Repository/InMemory/InMemoryAuthorizationCodeRepositoryTest.php
+++ b/test/Server/Repository/InMemory/InMemoryAuthorizationCodeRepositoryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\AuthorizationCode;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAuthorizationCodeRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(InMemoryAuthorizationCodeRepository::class)]
+final class InMemoryAuthorizationCodeRepositoryTest extends TestCase
+{
+    public function testPersistAndFindByCode(): void
+    {
+        $repo = new InMemoryAuthorizationCodeRepository();
+        $code = new AuthorizationCode(
+            'code1',
+            'c1',
+            'u1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        );
+        $repo->persist($code);
+        self::assertSame($code, $repo->findByCode('code1'));
+        self::assertNull($repo->findByCode('missing'));
+    }
+
+    public function testMarkUsedAndIsUsed(): void
+    {
+        $repo = new InMemoryAuthorizationCodeRepository();
+        $code = new AuthorizationCode(
+            'code1',
+            'c1',
+            'u1',
+            'https://example.com/cb',
+            'openid',
+            null,
+            null,
+            null,
+            new DateTimeImmutable('+10 minutes'),
+        );
+        $repo->persist($code);
+
+        self::assertFalse($repo->isUsed('code1'));
+        $repo->markUsed('code1');
+        self::assertTrue($repo->isUsed('code1'));
+        self::assertTrue($repo->findByCode('code1')->isUsed());
+    }
+}

--- a/test/Server/Repository/InMemory/InMemoryClientRepositoryTest.php
+++ b/test/Server/Repository/InMemory/InMemoryClientRepositoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryClientRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InMemoryClientRepository::class)]
+final class InMemoryClientRepositoryTest extends TestCase
+{
+    private function makeClient(string $id = 'c1', string $type = 'confidential'): Client
+    {
+        return new Client(
+            $id,
+            $type === 'confidential' ? password_hash('s', PASSWORD_BCRYPT) : null,
+            'Test',
+            ['https://example.com/cb'],
+            ['authorization_code'],
+            'openid',
+            $type,
+        );
+    }
+
+    public function testFindById(): void
+    {
+        $repo = new InMemoryClientRepository($this->makeClient('c1'));
+        self::assertNotNull($repo->findById('c1'));
+        self::assertNull($repo->findById('c2'));
+    }
+
+    public function testValidateClient(): void
+    {
+        $repo = new InMemoryClientRepository($this->makeClient('c1'));
+        self::assertTrue($repo->validateClient('c1', 's', 'authorization_code'));
+        self::assertFalse($repo->validateClient('c1', 'wrong', 'authorization_code'));
+        self::assertFalse($repo->validateClient('c1', 's', 'client_credentials'));
+        self::assertFalse($repo->validateClient('missing', 's', 'authorization_code'));
+    }
+
+    public function testValidatePublicClient(): void
+    {
+        $repo = new InMemoryClientRepository($this->makeClient('pub', 'public'));
+        self::assertTrue($repo->validateClient('pub', null, 'authorization_code'));
+    }
+}

--- a/test/Server/Repository/InMemory/InMemoryRefreshTokenRepositoryTest.php
+++ b/test/Server/Repository/InMemory/InMemoryRefreshTokenRepositoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\RefreshToken;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+
+#[CoversClass(InMemoryRefreshTokenRepository::class)]
+final class InMemoryRefreshTokenRepositoryTest extends TestCase
+{
+    public function testPersistAndFind(): void
+    {
+        $repo = new InMemoryRefreshTokenRepository();
+        $token = new RefreshToken('rt1', 'at1', 'c1', 'u1', 'openid', new DateTimeImmutable('+30 days'));
+        $repo->persist($token);
+        self::assertSame($token, $repo->findById('rt1'));
+    }
+
+    public function testRevokeAndIsRevoked(): void
+    {
+        $repo = new InMemoryRefreshTokenRepository();
+        $token = new RefreshToken('rt1', 'at1', 'c1', 'u1', 'openid', new DateTimeImmutable('+30 days'));
+        $repo->persist($token);
+
+        self::assertFalse($repo->isRevoked('rt1'));
+        $repo->revoke('rt1');
+        self::assertTrue($repo->isRevoked('rt1'));
+    }
+
+    public function testRevokeByAccessTokenId(): void
+    {
+        $repo = new InMemoryRefreshTokenRepository();
+        $repo->persist(new RefreshToken('rt1', 'at1', 'c1', 'u1', 'openid', new DateTimeImmutable('+30 days')));
+        $repo->persist(new RefreshToken('rt2', 'at1', 'c1', 'u1', 'openid', new DateTimeImmutable('+30 days')));
+        $repo->persist(new RefreshToken('rt3', 'at2', 'c1', 'u1', 'openid', new DateTimeImmutable('+30 days')));
+
+        $repo->revokeByAccessTokenId('at1');
+        self::assertTrue($repo->isRevoked('rt1'));
+        self::assertTrue($repo->isRevoked('rt2'));
+        self::assertFalse($repo->isRevoked('rt3'));
+    }
+}

--- a/test/Server/Repository/InMemory/InMemoryScopeRepositoryTest.php
+++ b/test/Server/Repository/InMemory/InMemoryScopeRepositoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Repository\InMemory;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryScopeRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InMemoryScopeRepository::class)]
+final class InMemoryScopeRepositoryTest extends TestCase
+{
+    public function testFindByIdentifier(): void
+    {
+        $repo = new InMemoryScopeRepository(new Scope('openid'), new Scope('profile'));
+        self::assertNotNull($repo->findByIdentifier('openid'));
+        self::assertNull($repo->findByIdentifier('email'));
+    }
+
+    public function testFinalizeScopesFiltersUnknown(): void
+    {
+        $repo = new InMemoryScopeRepository(new Scope('openid'), new Scope('profile'));
+        $client = new Client('c1', null, 'Test', [], ['authorization_code'], 'openid', 'public');
+        $requested = [new Scope('openid'), new Scope('admin')];
+        $result = $repo->finalizeScopes($requested, 'authorization_code', $client);
+        self::assertCount(1, $result);
+        self::assertSame('openid', $result[0]->identifier);
+    }
+
+    public function testFinalizeScopesDefaultsWhenEmpty(): void
+    {
+        $repo = new InMemoryScopeRepository(new Scope('openid'), new Scope('profile'));
+        $client = new Client('c1', null, 'Test', [], ['authorization_code'], 'openid profile', 'public');
+        $result = $repo->finalizeScopes([], 'authorization_code', $client);
+        self::assertCount(2, $result);
+    }
+}

--- a/test/Server/ServerMetadataTest.php
+++ b/test/Server/ServerMetadataTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server;
+
+use Horde\Oauth\Server\ServerMetadata;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ServerMetadata::class)]
+final class ServerMetadataTest extends TestCase
+{
+    private function createMetadata(): ServerMetadata
+    {
+        return new ServerMetadata(
+            issuer: 'https://example.com',
+            authorizationEndpoint: 'https://example.com/authorize',
+            tokenEndpoint: 'https://example.com/token',
+            revocationEndpoint: 'https://example.com/revoke',
+            jwksUri: 'https://example.com/.well-known/jwks.json',
+            userinfoEndpoint: 'https://example.com/userinfo',
+            scopesSupported: ['openid', 'profile', 'email'],
+        );
+    }
+
+    public function testToArrayIncludesRequired(): void
+    {
+        $meta = $this->createMetadata();
+        $arr = $meta->toArray();
+        self::assertSame('https://example.com', $arr['issuer']);
+        self::assertSame('https://example.com/authorize', $arr['authorization_endpoint']);
+        self::assertSame('https://example.com/token', $arr['token_endpoint']);
+        self::assertSame('https://example.com/revoke', $arr['revocation_endpoint']);
+        self::assertSame('https://example.com/.well-known/jwks.json', $arr['jwks_uri']);
+        self::assertSame(['openid', 'profile', 'email'], $arr['scopes_supported']);
+    }
+
+    public function testToArrayOmitsNulls(): void
+    {
+        $meta = new ServerMetadata(
+            issuer: 'https://example.com',
+            authorizationEndpoint: 'https://example.com/authorize',
+            tokenEndpoint: 'https://example.com/token',
+        );
+        $arr = $meta->toArray();
+        self::assertArrayNotHasKey('revocation_endpoint', $arr);
+        self::assertArrayNotHasKey('introspection_endpoint', $arr);
+        self::assertArrayNotHasKey('jwks_uri', $arr);
+        self::assertArrayNotHasKey('userinfo_endpoint', $arr);
+    }
+
+    public function testToJsonValid(): void
+    {
+        $meta = $this->createMetadata();
+        $json = $meta->toJson();
+        $decoded = json_decode($json, true);
+        self::assertSame('https://example.com', $decoded['issuer']);
+    }
+
+    public function testDefaults(): void
+    {
+        $meta = new ServerMetadata('https://ex.com', '/auth', '/token');
+        self::assertSame(['code'], $meta->responseTypesSupported);
+        self::assertContains('authorization_code', $meta->grantTypesSupported);
+        self::assertContains('S256', $meta->codeChallengeMethodsSupported);
+    }
+}

--- a/test/Server/Token/AccessTokenIssuerTest.php
+++ b/test/Server/Token/AccessTokenIssuerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Token;
+
+use Horde\Jwt\Key\PrivateKey;
+use Horde\Jwt\Signer\Rs256Signer;
+use Horde\Jwt\TokenEncoder;
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryAccessTokenRepository;
+use Horde\Oauth\Server\Token\AccessTokenIssuer;
+use Horde\Oauth\Test\RsaKeyHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AccessTokenIssuer::class)]
+final class AccessTokenIssuerTest extends TestCase
+{
+    use RsaKeyHelper;
+    private InMemoryAccessTokenRepository $tokenRepo;
+    private AccessTokenIssuer $issuer;
+
+    protected function setUp(): void
+    {
+        $rsaKey = self::generateRsaKey();
+        $this->tokenRepo = new InMemoryAccessTokenRepository();
+        $this->issuer = new AccessTokenIssuer(
+            new TokenEncoder(),
+            new Rs256Signer($rsaKey),
+            $this->tokenRepo,
+            'https://example.com',
+            3600,
+        );
+    }
+
+    public function testIssueReturnsRequiredFields(): void
+    {
+        $client = new Client('c1', null, 'Test', [], ['client_credentials'], 'api', 'public');
+        $scopes = [new Scope('openid'), new Scope('profile')];
+        $result = $this->issuer->issue($client, 'user1', $scopes);
+
+        self::assertArrayHasKey('access_token', $result);
+        self::assertSame('Bearer', $result['token_type']);
+        self::assertSame(3600, $result['expires_in']);
+        self::assertSame('openid profile', $result['scope']);
+        self::assertArrayHasKey('_jti', $result);
+    }
+
+    public function testIssuePersistsToken(): void
+    {
+        $client = new Client('c1', null, 'Test', [], ['client_credentials'], 'api', 'public');
+        $result = $this->issuer->issue($client, 'user1', [new Scope('openid')]);
+        $jti = $result['_jti'];
+        $entity = $this->tokenRepo->findById($jti);
+        self::assertNotNull($entity);
+        self::assertSame('c1', $entity->clientId);
+        self::assertSame('user1', $entity->identityId);
+    }
+
+    public function testIssueWithNullIdentity(): void
+    {
+        $client = new Client('c1', null, 'Test', [], ['client_credentials'], 'api', 'public');
+        $result = $this->issuer->issue($client, null, []);
+        self::assertArrayNotHasKey('scope', $result);
+        $entity = $this->tokenRepo->findById($result['_jti']);
+        self::assertNull($entity->identityId);
+    }
+
+    public function testAccessTokenIsValidJwt(): void
+    {
+        $client = new Client('c1', null, 'Test', [], ['client_credentials'], 'api', 'public');
+        $result = $this->issuer->issue($client, 'user1', [new Scope('api')]);
+        $parts = explode('.', $result['access_token']);
+        self::assertCount(3, $parts);
+    }
+}

--- a/test/Server/Token/RefreshTokenIssuerTest.php
+++ b/test/Server/Token/RefreshTokenIssuerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (BSD). If you
+ * did not receive this file, see http://www.horde.org/licenses/bsd.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Oauth\Test\Server\Token;
+
+use Horde\Oauth\Server\Entity\Client;
+use Horde\Oauth\Server\Entity\Scope;
+use Horde\Oauth\Server\Repository\InMemory\InMemoryRefreshTokenRepository;
+use Horde\Oauth\Server\Token\RefreshTokenIssuer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RefreshTokenIssuer::class)]
+final class RefreshTokenIssuerTest extends TestCase
+{
+    public function testIssueReturnsOpaqueToken(): void
+    {
+        $repo = new InMemoryRefreshTokenRepository();
+        $issuer = new RefreshTokenIssuer($repo);
+        $client = new Client('c1', null, 'Test', [], ['authorization_code'], 'openid', 'public');
+        $tokenId = $issuer->issue('at1', $client, 'user1', [new Scope('openid')]);
+
+        self::assertSame(64, strlen($tokenId));
+        self::assertMatchesRegularExpression('/^[0-9a-f]+$/', $tokenId);
+    }
+
+    public function testIssuePersists(): void
+    {
+        $repo = new InMemoryRefreshTokenRepository();
+        $issuer = new RefreshTokenIssuer($repo);
+        $client = new Client('c1', null, 'Test', [], ['authorization_code'], 'openid', 'public');
+        $tokenId = $issuer->issue('at1', $client, 'user1', [new Scope('openid')]);
+
+        $entity = $repo->findById($tokenId);
+        self::assertNotNull($entity);
+        self::assertSame('at1', $entity->accessTokenId);
+        self::assertSame('c1', $entity->clientId);
+        self::assertSame('user1', $entity->identityId);
+    }
+}


### PR DESCRIPTION
This started out as a rewrite of the existing code in horde/core and horde/components for the github api client and horde's own frontend JWT initiative. Once we had a truely generic JWT library horde/jwt it was the logical next step to spend a weekend for a draft of OAuth 2.0 and OpenID Connect support.

This library is deliberately incomplete. It does not come with a DB schema or any bindings into how the framework handles users and permissions. This is a job for another weekend and I also want to be a bit more strict observing the barrier between framework/app ecosystem and individual libraries.

I have only touched up and NOT ported the existing Oauth 1.0a client library we had. It still has some value but time is too tight and I need to do bug fix and maintenance work towards RC phase.