### PR TITLE
feat/revocation endpoint auth methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ run-tests.log
 /phpstan.neon
 # PHPStan cache directory
 /.phpstan.cache/
+
+# Added by horde-components QC --fix-qc-issues
+# Horde installer plugin runtime data
+/var/
+# Horde installer plugin web-accessible directory
+/web/

--- a/src/Client/OAuth2Client.php
+++ b/src/Client/OAuth2Client.php
@@ -219,6 +219,10 @@ final class OAuth2Client
     /**
      * Revoke a token at the provider's revocation endpoint (RFC 7009).
      *
+     * Client authentication uses revocation_endpoint_auth_methods_supported
+     * when advertised, falling back to token_endpoint_auth_methods_supported
+     * per RFC 8414 §2.
+     *
      * @param string $token          The token to revoke (access or refresh).
      * @param string $tokenTypeHint  'access_token' or 'refresh_token'.
      * @throws OAuthException        If the provider has no revocation endpoint
@@ -236,10 +240,13 @@ final class OAuth2Client
             'client_id'       => $this->clientId,
         ];
 
+        $authMethods = $this->provider->revocationEndpointAuthMethodsSupported
+            ?? $this->provider->tokenEndpointAuthMethodsSupported;
+
         $useBasic = false;
         if ($this->clientSecret !== null) {
-            $useBasic = in_array('client_secret_basic', $this->provider->tokenEndpointAuthMethodsSupported, true)
-                && !in_array('client_secret_post', $this->provider->tokenEndpointAuthMethodsSupported, true);
+            $useBasic = in_array('client_secret_basic', $authMethods, true)
+                && !in_array('client_secret_post', $authMethods, true);
 
             if (!$useBasic) {
                 $params['client_secret'] = $this->clientSecret;

--- a/src/Client/ProviderConfig.php
+++ b/src/Client/ProviderConfig.php
@@ -16,11 +16,15 @@ namespace Horde\OAuth\Client;
 final class ProviderConfig
 {
     /**
-     * @param string[] $scopesSupported
-     * @param string[] $responseTypesSupported
-     * @param string[] $grantTypesSupported
-     * @param string[] $tokenEndpointAuthMethodsSupported
-     * @param string[] $idTokenSigningAlgValuesSupported
+     * @param string[]      $scopesSupported
+     * @param string[]      $responseTypesSupported
+     * @param string[]      $grantTypesSupported
+     * @param string[]      $tokenEndpointAuthMethodsSupported
+     * @param string[]|null $revocationEndpointAuthMethodsSupported  RFC 8414
+     *      §2 override for the revocation endpoint. Null means "not
+     *      advertised; fall back to tokenEndpointAuthMethodsSupported per
+     *      RFC 8414 §2's specified default."
+     * @param string[]      $idTokenSigningAlgValuesSupported
      */
     public function __construct(
         public readonly string $issuer,
@@ -34,6 +38,7 @@ final class ProviderConfig
         public readonly array $responseTypesSupported = ['code'],
         public readonly array $grantTypesSupported = [],
         public readonly array $tokenEndpointAuthMethodsSupported = ['client_secret_basic'],
+        public readonly ?array $revocationEndpointAuthMethodsSupported = null,
         public readonly array $idTokenSigningAlgValuesSupported = [],
     ) {}
 
@@ -54,6 +59,9 @@ final class ProviderConfig
             responseTypesSupported: (array) ($data['response_types_supported'] ?? ['code']),
             grantTypesSupported: (array) ($data['grant_types_supported'] ?? []),
             tokenEndpointAuthMethodsSupported: (array) ($data['token_endpoint_auth_methods_supported'] ?? ['client_secret_basic']),
+            revocationEndpointAuthMethodsSupported: isset($data['revocation_endpoint_auth_methods_supported'])
+                ? (array) $data['revocation_endpoint_auth_methods_supported']
+                : null,
             idTokenSigningAlgValuesSupported: (array) ($data['id_token_signing_alg_values_supported'] ?? []),
         );
     }
@@ -75,6 +83,7 @@ final class ProviderConfig
             'response_types_supported' => $this->responseTypesSupported,
             'grant_types_supported' => $this->grantTypesSupported,
             'token_endpoint_auth_methods_supported' => $this->tokenEndpointAuthMethodsSupported,
+            'revocation_endpoint_auth_methods_supported' => $this->revocationEndpointAuthMethodsSupported,
             'id_token_signing_alg_values_supported' => $this->idTokenSigningAlgValuesSupported,
         ], static fn($v) => $v !== null && $v !== []);
     }

--- a/test/Client/OAuth2ClientTest.php
+++ b/test/Client/OAuth2ClientTest.php
@@ -36,10 +36,10 @@ final class OAuth2ClientTest extends TestCase
     protected function setUp(): void
     {
         $this->provider = ProviderConfig::fromArray([
-            'issuer'                 => 'https://idp.example.org',
-            'authorization_endpoint' => 'https://idp.example.org/authorize',
-            'token_endpoint'         => 'https://idp.example.org/token',
-            'revocation_endpoint'    => 'https://idp.example.org/revoke',
+            'issuer'                                => 'https://idp.example.org',
+            'authorization_endpoint'                => 'https://idp.example.org/authorize',
+            'token_endpoint'                        => 'https://idp.example.org/token',
+            'revocation_endpoint'                   => 'https://idp.example.org/revoke',
             'token_endpoint_auth_methods_supported' => ['client_secret_post'],
         ]);
 
@@ -69,6 +69,47 @@ final class OAuth2ClientTest extends TestCase
         );
     }
 
+    /**
+     * Returns a stream factory whose createStream() captures the body string
+     * passed in, then returns the shared $this->stream stub. Use when a test
+     * needs to assert on the wire body without touching a real HTTP layer.
+     */
+    private function captureStreamBody(?string &$captured): StreamFactoryInterface
+    {
+        $factory = $this->createStub(StreamFactoryInterface::class);
+        $factory->method('createStream')
+            ->willReturnCallback(function (string $body) use (&$captured): StreamInterface {
+                $captured = $body;
+                return $this->stream;
+            });
+        return $factory;
+    }
+
+    /**
+     * Returns a fresh RequestInterface stub (NOT $this->request) whose
+     * withHeader() captures any "Authorization" value into $captured and
+     * returns itself. withBody() also returns itself so the production
+     * code's fluent chain (withHeader()->withHeader()->withBody()->...)
+     * resolves correctly.
+     *
+     * Using a fresh stub here — instead of re-stubbing $this->request from
+     * setUp() — avoids PHPUnit's matcher-fallthrough behaviour when the
+     * same method is configured twice on the same stub.
+     */
+    private function captureAuthHeader(?string &$captured): RequestInterface
+    {
+        $request = $this->createStub(RequestInterface::class);
+        $request->method('withBody')->willReturn($request);
+        $request->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$captured, $request): RequestInterface {
+                if ($name === 'Authorization') {
+                    $captured = $value;
+                }
+                return $request;
+            });
+        return $request;
+    }
+
     public function testRevokeTokenSendsPostToRevocationEndpoint(): void
     {
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
@@ -96,12 +137,7 @@ final class OAuth2ClientTest extends TestCase
         $requestFactory->method('createRequest')->willReturn($this->request);
 
         $capturedBody = null;
-        $streamFactory = $this->createStub(StreamFactoryInterface::class);
-        $streamFactory->method('createStream')
-            ->willReturnCallback(function (string $body) use (&$capturedBody): StreamInterface {
-                $capturedBody = $body;
-                return $this->stream;
-            });
+        $streamFactory = $this->captureStreamBody($capturedBody);
 
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
@@ -133,12 +169,7 @@ final class OAuth2ClientTest extends TestCase
         $requestFactory->method('createRequest')->willReturn($this->request);
 
         $capturedBody = null;
-        $streamFactory = $this->createStub(StreamFactoryInterface::class);
-        $streamFactory->method('createStream')
-            ->willReturnCallback(function (string $body) use (&$capturedBody): StreamInterface {
-                $capturedBody = $body;
-                return $this->stream;
-            });
+        $streamFactory = $this->captureStreamBody($capturedBody);
 
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
@@ -167,12 +198,7 @@ final class OAuth2ClientTest extends TestCase
         $requestFactory->method('createRequest')->willReturn($this->request);
 
         $capturedBody = null;
-        $streamFactory = $this->createStub(StreamFactoryInterface::class);
-        $streamFactory->method('createStream')
-            ->willReturnCallback(function (string $body) use (&$capturedBody): StreamInterface {
-                $capturedBody = $body;
-                return $this->stream;
-            });
+        $streamFactory = $this->captureStreamBody($capturedBody);
 
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
@@ -242,32 +268,21 @@ final class OAuth2ClientTest extends TestCase
     public function testRevokeTokenUsesBasicAuthWhenConfigured(): void
     {
         $provider = ProviderConfig::fromArray([
-            'issuer'                                    => 'https://idp.example.org',
-            'authorization_endpoint'                    => 'https://idp.example.org/authorize',
-            'token_endpoint'                            => 'https://idp.example.org/token',
-            'revocation_endpoint'                       => 'https://idp.example.org/revoke',
-            'token_endpoint_auth_methods_supported'     => ['client_secret_basic'],
+            'issuer'                                => 'https://idp.example.org',
+            'authorization_endpoint'                => 'https://idp.example.org/authorize',
+            'token_endpoint'                        => 'https://idp.example.org/token',
+            'revocation_endpoint'                   => 'https://idp.example.org/revoke',
+            'token_endpoint_auth_methods_supported' => ['client_secret_basic'],
         ]);
 
-        $requestFactory = $this->createStub(RequestFactoryInterface::class);
-        $requestFactory->method('createRequest')->willReturn($this->request);
-
-        $capturedBody = null;
         $capturedAuth = null;
-        $this->request->method('withHeader')
-            ->willReturnCallback(function (string $name, string $value) use (&$capturedAuth): RequestInterface {
-                if ($name === 'Authorization') {
-                    $capturedAuth = $value;
-                }
-                return $this->request;
-            });
+        $request      = $this->captureAuthHeader($capturedAuth);
 
-        $streamFactory = $this->createStub(StreamFactoryInterface::class);
-        $streamFactory->method('createStream')
-            ->willReturnCallback(function (string $body) use (&$capturedBody): StreamInterface {
-                $capturedBody = $body;
-                return $this->stream;
-            });
+        $requestFactory = $this->createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $capturedBody  = null;
+        $streamFactory = $this->captureStreamBody($capturedBody);
 
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
@@ -308,13 +323,8 @@ final class OAuth2ClientTest extends TestCase
         $requestFactory = $this->createStub(RequestFactoryInterface::class);
         $requestFactory->method('createRequest')->willReturn($this->request);
 
-        $capturedBody = null;
-        $streamFactory = $this->createStub(StreamFactoryInterface::class);
-        $streamFactory->method('createStream')
-            ->willReturnCallback(function (string $body) use (&$capturedBody): StreamInterface {
-                $capturedBody = $body;
-                return $this->stream;
-            });
+        $capturedBody  = null;
+        $streamFactory = $this->captureStreamBody($capturedBody);
 
         $response = $this->createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);

--- a/test/Client/OAuth2ClientTest.php
+++ b/test/Client/OAuth2ClientTest.php
@@ -40,7 +40,7 @@ final class OAuth2ClientTest extends TestCase
             'authorization_endpoint' => 'https://idp.example.org/authorize',
             'token_endpoint'         => 'https://idp.example.org/token',
             'revocation_endpoint'    => 'https://idp.example.org/revoke',
-	    'token_endpoint_auth_methods_supported' => ['client_secret_post'],
+            'token_endpoint_auth_methods_supported' => ['client_secret_post'],
         ]);
 
         $this->stream        = $this->createStub(StreamInterface::class);
@@ -59,13 +59,13 @@ final class OAuth2ClientTest extends TestCase
         ?ProviderConfig $provider = null,
     ): OAuth2Client {
         return new OAuth2Client(
-            provider:       $provider ?? $this->provider,
-            clientId:       'test-client',
-            clientSecret:   $clientSecret,
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $provider ?? $this->provider,
+            clientId: 'test-client',
+            clientSecret: $clientSecret,
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $this->streamFactory,
+            streamFactory: $this->streamFactory,
         );
     }
 
@@ -110,13 +110,13 @@ final class OAuth2ClientTest extends TestCase
         $httpClient->method('sendRequest')->willReturn($response);
 
         $client = new OAuth2Client(
-            provider:       $this->provider,
-            clientId:       'test-client',
-            clientSecret:   'secret',
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $this->provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $streamFactory,
+            streamFactory: $streamFactory,
         );
 
         $client->revokeToken('my-access-token', 'access_token');
@@ -147,13 +147,13 @@ final class OAuth2ClientTest extends TestCase
         $httpClient->method('sendRequest')->willReturn($response);
 
         $client = new OAuth2Client(
-            provider:       $this->provider,
-            clientId:       'test-client',
-            clientSecret:   'secret',
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $this->provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $streamFactory,
+            streamFactory: $streamFactory,
         );
 
         $client->revokeToken('my-token');
@@ -181,13 +181,13 @@ final class OAuth2ClientTest extends TestCase
         $httpClient->method('sendRequest')->willReturn($response);
 
         $client = new OAuth2Client(
-            provider:       $this->provider,
-            clientId:       'test-client',
-            clientSecret:   null,
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $this->provider,
+            clientId: 'test-client',
+            clientSecret: null,
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $streamFactory,
+            streamFactory: $streamFactory,
         );
 
         $client->revokeToken('my-token');
@@ -207,13 +207,13 @@ final class OAuth2ClientTest extends TestCase
         $requestFactory = $this->createStub(RequestFactoryInterface::class);
 
         $client = new OAuth2Client(
-            provider:       $provider,
-            clientId:       'test-client',
-            clientSecret:   'secret',
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $this->streamFactory,
+            streamFactory: $this->streamFactory,
         );
 
         $this->expectException(OAuthException::class);
@@ -276,13 +276,13 @@ final class OAuth2ClientTest extends TestCase
         $httpClient->method('sendRequest')->willReturn($response);
 
         $client = new OAuth2Client(
-            provider:       $provider,
-            clientId:       'test-client',
-            clientSecret:   'secret',
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $streamFactory,
+            streamFactory: $streamFactory,
         );
 
         $client->revokeToken('my-token');
@@ -323,13 +323,13 @@ final class OAuth2ClientTest extends TestCase
         $httpClient->method('sendRequest')->willReturn($response);
 
         $client = new OAuth2Client(
-            provider:       $provider,
-            clientId:       'test-client',
-            clientSecret:   'secret',
-            redirectUri:    'https://horde.example.org/callback',
-            httpClient:     $httpClient,
+            provider: $provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
             requestFactory: $requestFactory,
-            streamFactory:  $streamFactory,
+            streamFactory: $streamFactory,
         );
 
         $client->revokeToken('my-token');

--- a/test/Client/OAuth2ClientTest.php
+++ b/test/Client/OAuth2ClientTest.php
@@ -346,4 +346,91 @@ final class OAuth2ClientTest extends TestCase
 
         self::assertStringContainsString('client_secret=secret', $capturedBody);
     }
+
+    public function testRevokeTokenPrefersRevocationAuthMethodsWhenAdvertised(): void
+    {
+        // Token endpoint advertises post; revocation endpoint advertises
+        // basic only. The override must win for revokeToken().
+        $provider = ProviderConfig::fromArray([
+            'issuer'                                     => 'https://idp.example.org',
+            'authorization_endpoint'                     => 'https://idp.example.org/authorize',
+            'token_endpoint'                             => 'https://idp.example.org/token',
+            'revocation_endpoint'                        => 'https://idp.example.org/revoke',
+            'token_endpoint_auth_methods_supported'      => ['client_secret_post'],
+            'revocation_endpoint_auth_methods_supported' => ['client_secret_basic'],
+        ]);
+
+        $capturedAuth = null;
+        $request      = $this->captureAuthHeader($capturedAuth);
+
+        $requestFactory = $this->createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $capturedBody  = null;
+        $streamFactory = $this->captureStreamBody($capturedBody);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($response);
+
+        $client = new OAuth2Client(
+            provider: $provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
+            requestFactory: $requestFactory,
+            streamFactory: $streamFactory,
+        );
+
+        $client->revokeToken('my-token');
+
+        self::assertStringNotContainsString('client_secret', $capturedBody);
+        self::assertStringStartsWith('Basic ', $capturedAuth);
+    }
+
+    public function testRevokeTokenFallsBackToTokenAuthMethodsWhenRevocationNotAdvertised(): void
+    {
+        // Revocation endpoint advertises no auth methods. Per RFC 8414 §2,
+        // fall back to the token endpoint's advertised methods.
+        $provider = ProviderConfig::fromArray([
+            'issuer'                                => 'https://idp.example.org',
+            'authorization_endpoint'                => 'https://idp.example.org/authorize',
+            'token_endpoint'                        => 'https://idp.example.org/token',
+            'revocation_endpoint'                   => 'https://idp.example.org/revoke',
+            'token_endpoint_auth_methods_supported' => ['client_secret_basic'],
+        ]);
+
+        $capturedAuth = null;
+        $request      = $this->captureAuthHeader($capturedAuth);
+
+        $requestFactory = $this->createStub(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
+
+        $capturedBody  = null;
+        $streamFactory = $this->captureStreamBody($capturedBody);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createStub(ClientInterface::class);
+        $httpClient->method('sendRequest')->willReturn($response);
+
+        $client = new OAuth2Client(
+            provider: $provider,
+            clientId: 'test-client',
+            clientSecret: 'secret',
+            redirectUri: 'https://horde.example.org/callback',
+            httpClient: $httpClient,
+            requestFactory: $requestFactory,
+            streamFactory: $streamFactory,
+        );
+
+        $client->revokeToken('my-token');
+
+        self::assertStringNotContainsString('client_secret', $capturedBody);
+        self::assertStringStartsWith('Basic ', $capturedAuth);
+    }
 }


### PR DESCRIPTION
Minor follow up to @jcdelepine's #5 

The RFC allows a separate advertising field for the revocation endpoint auth methods. If not present, reuse the authentication endpoint as in #5 
